### PR TITLE
Add Shopify RESTful API Access Scopes endpoint. [CH4190]

### DIFF
--- a/lib/shopify_api/rest/access_scope.ex
+++ b/lib/shopify_api/rest/access_scope.ex
@@ -1,0 +1,20 @@
+defmodule ShopifyApi.Rest.AccessScope do
+  @moduledoc """
+  Shopify REST API Access Scope resources.
+  """
+
+  alias ShopifyApi.AuthToken
+  alias ShopifyApi.Rest.Request
+
+  @doc """
+  Return a list of all access scopes associated with the access token.
+
+  ## Example
+
+      iex> ShopifyApi.Rest.AccessScope.get(auth)
+      {:ok, %{ "access_scopes" => [] }}
+  """
+  def get(%AuthToken{} = auth) do
+    Request.get(auth, "oauth/access_scopes.json")
+  end
+end


### PR DESCRIPTION
```exs
iex(6)> ShopifyApi.Rest.AccessScope.get(token)
{:ok,
 %{
   "access_scopes" => [
     %{"handle" => "read_orders"},
     %{"handle" => "write_products"},
     %{"handle" => "read_products"}
   ]
 }}

```