### PR TITLE
Cleaned up event queue duplication and had to bump version number up.

### DIFF
--- a/lib/shopify_api/event_pipe/event_queue.ex
+++ b/lib/shopify_api/event_pipe/event_queue.ex
@@ -2,25 +2,26 @@ defmodule ShopifyAPI.EventPipe.EventQueue do
   require Logger
 
   def enqueue(%{destination: :shopify, object: %{product: %{}}} = event) do
-    Logger.info(fn -> "Enqueueing #{inspect(event)}" end)
-    Exq.enqueue(Exq, "outbound", ShopifyAPI.EventPipe.ProductWorker, [event])
+    enqueue_event(ShopifyAPI.EventPipe.ProductWorker, event)
   end
 
   def enqueue(%{destination: :shopify, object: %{variant: %{}}} = event) do
-    Logger.info(fn -> "Enqueueing #{inspect(event)}" end)
-    Exq.enqueue(Exq, "outbound", ShopifyAPI.EventPipe.VariantWorker, [event])
+    enqueue_event(ShopifyAPI.EventPipe.VariantWorker, event)
   end
 
   def enqueue(%{destination: :shopify, object: %{inventory_level: %{}}} = event) do
-    Logger.info(fn -> "Enqueueing #{inspect(event)}" end)
-    Exq.enqueue(Exq, "outbound", ShopifyAPI.EventPipe.InventoryLevelWorker, [event])
+    enqueue_event(ShopifyAPI.EventPipe.InventoryLevelWorker, event)
   end
 
   def enqueue(%{destination: :shopify, object: %{location: %{}}} = event) do
-    Logger.info(fn -> "Enqueueing #{inspect(event)}" end)
-    Exq.enqueue(Exq, "outbound", ShopifyAPI.EventPipe.LocationWorker, [event])
+    enqueue_event(ShopifyAPI.EventPipe.LocationWorker, event)
   end
 
   def enqueue(event),
     do: Logger.warn("#{__MODULE__} does not know what worker should handle #{inspect(event)}")
+
+  defp enqueue_event(worker, event) do
+    Logger.info(fn -> "Enqueueing #{inspect(event)}" end)
+    Exq.enqueue(Exq, "outbound", worker, [event])
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.1.15"
+  @version "0.1.16"
 
   def project do
     [


### PR DESCRIPTION
`0.1.15` actually already got tagged last week, so need to bump up to `0.1.16`.