### PR TITLE
Add 'assigns' field to %EventPipe.Event{}

### DIFF
--- a/lib/shopify_api/event_pipe/event.ex
+++ b/lib/shopify_api/event_pipe/event.ex
@@ -5,13 +5,15 @@ defmodule ShopifyAPI.EventPipe.Event do
             token: %{},
             object: nil,
             callback: nil,
-            action: :none
+            action: :none,
+            assigns: %{}
 
   @type t :: %__MODULE__{
           destination: atom(),
           token: map(),
           object: any(),
           callback: any(),
-          action: atom()
+          action: atom(),
+          assigns: map()
         }
 end


### PR DESCRIPTION
Similar to `Plug.Conn`, this field can be used to store additional, contextual information in an Event struct. The `ShopifyAPI` application itself will not make use of this field.

This can be quite useful if you need to round-trip information through the `EventPipe`, to perform additional processing in a callback function.