### PR TITLE
Correct signature of REST.Refund.calculate/3

### DIFF
--- a/lib/shopify_api/rest/refund.ex
+++ b/lib/shopify_api/rest/refund.ex
@@ -32,11 +32,11 @@ defmodule ShopifyAPI.REST.Refund do
 
   ## Example
 
-      iex> ShopifyAPI.REST.Refund.calculate(auth, integer)
+      iex> ShopifyAPI.REST.Refund.calculate(auth, integer, map)
       {:ok, { "refund" => %{} }}
   """
-  def calculate(%AuthToken{} = auth, order_id),
-    do: Request.post(auth, "orders/#{order_id}/refunds/calculate.json")
+  def calculate(%AuthToken{} = auth, order_id, %{refund: %{}} = refund),
+    do: Request.post(auth, "orders/#{order_id}/refunds/calculate.json", refund)
 
   @doc """
   Create a refund.


### PR DESCRIPTION
This is a POST request that accepts proposed refund information, so it requires a third parameter in our wrapper.