### PR TITLE
Feature/shop app init persistance config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 by adding `shopify_api` to your list of dependencies in `mix.exs` and add the application to the `extra_applications`:
 
 ```elixir
-def application do
-  [
-    mod: {...}
-    extra_applications: [..., :shopify_api]
-  ]
-end
-
 def deps do
   [
     {:shopify_api, "~> 0.1.0"}
@@ -22,19 +15,32 @@ end
 
 Add it to your phoenix routes.
 
-```
+```elixir
 scope "/shop" do
   forward("/", ShopifyAPI.Router)
 end
 ```
 
 If you want to be able to handle webhooks you need to add this to your endpoint before the parsers section
-```
+```elixir
 plug(ShopifyAPI.Plugs.Webhook, mount: "/shop/webhooks")
 ```
 
-Optional, add graphiql to your phoenix routes
+If you want persisted Apps, Shops, and Tokens add configuration to your functions.
+```elixir
+config :shopify_api, ShopifyAPI.AuthTokenServer,
+  initializer: {MyApp.AuthToken, :init, []},
+  persistance: {MyApp.AuthToken, :save, []}
+config :shopify_api, ShopifyAPI.AppServer,
+  initializer: {MyApp.ShopifyApp, :init, []},
+  persistance: {MyApp.ShopifyApp, :save, []}
+config :shopify_api, ShopifyAPI.ShopServer,
+  initializer: {MyApp.Shop, :init, []},
+  persistance: {MyApp.Shop, :save, []}
 ```
+
+Optional, add graphiql to your phoenix routes
+```elixir
 if Mix.env == :dev do
   forward(
     "/graphiql",

--- a/lib/shopify_api/app_server.ex
+++ b/lib/shopify_api/app_server.ex
@@ -6,10 +6,10 @@ defmodule ShopifyAPI.AppServer do
 
   def start_link(_opts) do
     Logger.info(fn -> "Starting #{__MODULE__}..." end)
-    state = Application.get_env(:shopify_api, ShopifyAPI.AppServer)
-    state = for {k, v} <- state, into: %{}, do: {k, struct(ShopifyAPI.App, v)}
-    Logger.info(fn -> "#{__MODULE__} loaded with #{inspect(state)}" end)
-    GenServer.start_link(__MODULE__, state, name: @name)
+
+    pid = GenServer.start_link(__MODULE__, %{}, name: @name)
+    call_initializer(app_server_config(:initializer))
+    pid
   end
 
   def all, do: GenServer.call(@name, :all)
@@ -39,6 +39,9 @@ defmodule ShopifyAPI.AppServer do
         end
       end)
 
+    # TODO should this be in a seperate process? It could tie up the GenServer
+    persist(app_server_config(:persistance), name, Map.get(new_state, name))
+
     {:noreply, new_state}
   end
 
@@ -50,4 +53,16 @@ defmodule ShopifyAPI.AppServer do
 
   @impl true
   def handle_call(:count, _caller, state), do: {:reply, Enum.count(state), state}
+
+  def app_server_config(key), do: Application.get_env(:shopify_api, ShopifyAPI.AppServer)[key]
+
+  def call_initializer({module, function, _}) when is_atom(module) and is_atom(function),
+    do: apply(module, function, [])
+
+  defp call_initializer(_), do: %{}
+
+  defp persist({module, function, _}, key, value) when is_atom(module) and is_atom(function),
+    do: apply(module, function, [key, value])
+
+  defp persist(_, _, _), do: nil
 end

--- a/lib/shopify_api/plugs/webhook.ex
+++ b/lib/shopify_api/plugs/webhook.ex
@@ -41,7 +41,7 @@ defmodule ShopifyAPI.Plugs.Webhook do
     %Event{
       destination: :client,
       app: conn.assigns.app,
-      shop: conn.assigns.shop,
+      shop: Map.get(conn.assigns, :shop),
       action: conn.assigns.shopify_event,
       object: conn.body_params
     }
@@ -61,7 +61,7 @@ defmodule ShopifyAPI.Plugs.Webhook do
   end
 
   defp fetch_shop(conn) do
-    case conn |> fetch_shop_name |> ShopServer.get() do
+    case conn |> fetch_shop_name() |> ShopServer.get() do
       {:ok, shop} ->
         Conn.assign(conn, :shop, shop)
 

--- a/lib/shopify_api/plugs/webhook.ex
+++ b/lib/shopify_api/plugs/webhook.ex
@@ -70,12 +70,10 @@ defmodule ShopifyAPI.Plugs.Webhook do
     end
   end
 
-  defp fetch_app_name(conn) do
-    List.last(conn.path_info)
-  end
+  defp fetch_app_name(conn), do: List.last(conn.path_info)
 
   defp fetch_app(conn) do
-    case conn |> fetch_app_name |> AppServer.get() do
+    case conn |> fetch_app_name() |> AppServer.get() do
       {:ok, app} ->
         Conn.assign(conn, :app, app)
 

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -9,11 +9,10 @@ defmodule ShopifyAPI.ShopServer do
 
   def start_link(_opts) do
     Logger.info(fn -> "Starting #{__MODULE__}..." end)
-    # TODO have some sane way to handle this config not existing
-    state = Application.get_env(:shopify_api, ShopifyAPI.ShopServer)
-    state = for {k, v} <- state, into: %{}, do: {k, struct(Shop, v)}
-    Logger.info(fn -> "#{__MODULE__} started with #{inspect(state)}" end)
-    GenServer.start_link(__MODULE__, state, name: @name)
+
+    pid = GenServer.start_link(__MODULE__, %{}, name: @name)
+    call_initializer(shop_server_config(:initializer))
+    pid
   end
 
   def all, do: GenServer.call(@name, :all)
@@ -38,6 +37,9 @@ defmodule ShopifyAPI.ShopServer do
   def handle_cast({:set, domain, new_values}, %{} = state) do
     new_state = Map.update(state, domain, %Shop{domain: domain}, &Map.merge(&1, new_values))
 
+    # TODO should this be in a seperate process? It could tie up the GenServer
+    persist(shop_server_config(:persistance), domain, Map.get(new_state, domain))
+
     {:noreply, new_state}
   end
 
@@ -49,4 +51,16 @@ defmodule ShopifyAPI.ShopServer do
 
   @impl true
   def handle_call(:count, _caller, state), do: {:reply, Enum.count(state), state}
+
+  def shop_server_config(key), do: Application.get_env(:shopify_api, ShopifyAPI.ShopServer)[key]
+
+  def call_initializer({module, function, _}) when is_atom(module) and is_atom(function),
+    do: apply(module, function, [])
+
+  def call_initializer(_), do: %{}
+
+  defp persist({module, function, _}, key, value) when is_atom(module) and is_atom(function),
+    do: apply(module, function, [key, value])
+
+  defp persist(_, _, _), do: nil
 end

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -10,9 +10,7 @@ defmodule ShopifyAPI.ShopServer do
   def start_link(_opts) do
     Logger.info(fn -> "Starting #{__MODULE__}..." end)
 
-    pid = GenServer.start_link(__MODULE__, %{}, name: @name)
-    call_initializer(shop_server_config(:initializer))
-    pid
+    GenServer.start_link(__MODULE__, %{}, name: @name)
   end
 
   def all, do: GenServer.call(@name, :all)
@@ -30,7 +28,12 @@ defmodule ShopifyAPI.ShopServer do
   #
 
   @impl true
-  def init(state), do: {:ok, state}
+  def init(state), do: {:ok, state, {:continue, :initialize}}
+
+  @impl true
+  @callback handle_cast(atom, map) :: tuple
+  def handle_continue(:initialize, state),
+    do: {:noreply, call_initializer(shop_server_config(:initializer))}
 
   @impl true
   @callback handle_cast(map, map) :: tuple
@@ -52,12 +55,12 @@ defmodule ShopifyAPI.ShopServer do
   @impl true
   def handle_call(:count, _caller, state), do: {:reply, Enum.count(state), state}
 
-  def shop_server_config(key), do: Application.get_env(:shopify_api, ShopifyAPI.ShopServer)[key]
+  defp shop_server_config(key), do: Application.get_env(:shopify_api, ShopifyAPI.ShopServer)[key]
 
-  def call_initializer({module, function, _}) when is_atom(module) and is_atom(function),
+  defp call_initializer({module, function, _}) when is_atom(module) and is_atom(function),
     do: apply(module, function, [])
 
-  def call_initializer(_), do: %{}
+  defp call_initializer(_), do: %{}
 
   defp persist({module, function, _}, key, value) when is_atom(module) and is_atom(function),
     do: apply(module, function, [key, value])


### PR DESCRIPTION
Following the format used by AuthTokenServer added initialization
and persistence configuration options to App and Shop servers. If you
have the old setup all thats needed is a configuration like:


```elixir
config :shopify_api, ShopifyAPI.AppServer, initializer: {MyApp.ShopifyApp, :init, []}

defmodule MyApp.ShopifyApp do
	def init() do
    	        state = Application.get_env(:shopify_api, ShopifyAPI.AppServer)
    	        state = for {k, v} <- state, into: %{}, do: {k, struct(ShopifyAPI.App, v)}
		state
	end
end
```