### PR TITLE
Expand Event struct to include response.

### DIFF
--- a/lib/shopify_api/event_pipe/event.ex
+++ b/lib/shopify_api/event_pipe/event.ex
@@ -9,11 +9,13 @@ defmodule ShopifyAPI.EventPipe.Event do
             assigns: %{},
             response: nil
 
+  @type callback :: (ShopifyAPI.AuthToken.t(), t() -> any())
+
   @type t :: %__MODULE__{
           destination: atom(),
           token: map(),
           object: any(),
-          callback: any(),
+          callback: nil | callback(),
           action: atom() | String.t(),
           assigns: map(),
           response: any()

--- a/lib/shopify_api/event_pipe/event.ex
+++ b/lib/shopify_api/event_pipe/event.ex
@@ -6,14 +6,16 @@ defmodule ShopifyAPI.EventPipe.Event do
             object: nil,
             callback: nil,
             action: :none,
-            assigns: %{}
+            assigns: %{},
+            response: nil
 
   @type t :: %__MODULE__{
           destination: atom(),
           token: map(),
           object: any(),
           callback: any(),
-          action: atom(),
-          assigns: map()
+          action: atom() | String.t(),
+          assigns: map(),
+          response: any()
         }
 end

--- a/lib/shopify_api/event_pipe/worker.ex
+++ b/lib/shopify_api/event_pipe/worker.ex
@@ -4,10 +4,12 @@ defmodule ShopifyAPI.EventPipe.Worker do
   """
   require Logger
   alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.EventPipe.Event
 
+  @type work :: (AuthToken.t(), Event.t() -> any())
   def perform(event), do: Logger.warn(fn -> "Failed to process event: #{inspect(event)}" end)
 
-  @spec execute_action(ShopifyAPI.EventPipe.Event.t(), any()) :: any()
+  @spec execute_action(Event.t(), work()) :: any()
   def execute_action(event, work) when is_function(work) do
     Logger.info(fn -> "#{__MODULE__} is processing an event: #{inspect(event)}" end)
 

--- a/lib/shopify_api/event_pipe/worker.ex
+++ b/lib/shopify_api/event_pipe/worker.ex
@@ -6,10 +6,10 @@ defmodule ShopifyAPI.EventPipe.Worker do
   alias ShopifyAPI.AuthToken
   alias ShopifyAPI.EventPipe.Event
 
-  @type work :: (AuthToken.t(), Event.t() -> any())
+  @spec perform(Event.t()) :: :ok | {:error, any()}
   def perform(event), do: Logger.warn(fn -> "Failed to process event: #{inspect(event)}" end)
 
-  @spec execute_action(Event.t(), work()) :: any()
+  @spec execute_action(Event.t(), Event.callback()) :: any()
   def execute_action(event, work) when is_function(work) do
     Logger.info(fn -> "#{__MODULE__} is processing an event: #{inspect(event)}" end)
 

--- a/lib/shopify_api/event_pipe/worker.ex
+++ b/lib/shopify_api/event_pipe/worker.ex
@@ -7,6 +7,7 @@ defmodule ShopifyAPI.EventPipe.Worker do
 
   def perform(event), do: Logger.warn(fn -> "Failed to process event: #{inspect(event)}" end)
 
+  @spec execute_action(ShopifyAPI.EventPipe.Event.t(), any()) :: any()
   def execute_action(event, work) when is_function(work) do
     Logger.info(fn -> "#{__MODULE__} is processing an event: #{inspect(event)}" end)
 


### PR DESCRIPTION
The response is added to the Event after execution, but is not defined in the defstruct. This can cause dialyzer errors if you are attempting to use the Event type in your spec. 