### PR TITLE
Set min Elixir version to 1.7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 21.2
-elixir 1.8.1
+erlang 21.3
+elixir 1.7.3-otp-21

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
-elixir: '1.8.1'
+elixir: '1.7.3'
 otp_release: '21.3'
 sudo: required
 services:

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Plug.ShopifyAPI.MixProject do
     [
       app: :shopify_api,
       version: @version,
-      elixir: "~> 1.8",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [plt_add_deps: :transitive, plt_file: {:no_warn, "priv/plts/dialyzer.plt"}],


### PR DESCRIPTION
Set min Elixir version to 1.7. 
Use Elixir 1.7.3 in `.tool-versions` and `.travis.yml`