### PR TITLE
Event struct typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Changed Event.t() typespec to be strings for destination and action. 
+- Coerce events from the queue into %Events{}
+
 ## 0.2.7
 
 - Added new endpoint for customer search

--- a/config/config.exs
+++ b/config/config.exs
@@ -46,7 +46,8 @@ config :exq,
     Exq.Middleware.Job,
     Exq.Middleware.Manager,
     Exq.Middleware.Logger,
-    Exq.Middleware.AtomizeJobArguments
+    Exq.Middleware.AtomizeJobArguments,
+    ShopifyAPI.Middleware.EventStructCoercer
   ]
 
 # Import environment specific config. This must remain at the bottom

--- a/lib/shopify_api/event_pipe/application_worker.ex
+++ b/lib/shopify_api/event_pipe/application_worker.ex
@@ -3,8 +3,8 @@ defmodule ShopifyAPI.EventPipe.ApplicationWorker do
   Worker for processing application destined jobs
   """
   import ShopifyAPI.EventPipe.Worker
-  alias ShopifyAPI.Shop
   alias ShopifyAPI.EventPipe.Event
+  alias ShopifyAPI.Shop
 
   def perform(%Event{action: "post_install", token: _} = event) do
     execute_action(event, fn token, _ ->

--- a/lib/shopify_api/event_pipe/application_worker.ex
+++ b/lib/shopify_api/event_pipe/application_worker.ex
@@ -4,8 +4,9 @@ defmodule ShopifyAPI.EventPipe.ApplicationWorker do
   """
   import ShopifyAPI.EventPipe.Worker
   alias ShopifyAPI.Shop
+  alias ShopifyAPI.EventPipe.Event
 
-  def perform(%{action: "post_install", token: _} = event) do
+  def perform(%Event{action: "post_install", token: _} = event) do
     execute_action(event, fn token, _ ->
       Shop.post_install(token)
     end)

--- a/lib/shopify_api/event_pipe/event.ex
+++ b/lib/shopify_api/event_pipe/event.ex
@@ -1,22 +1,22 @@
 defmodule ShopifyAPI.EventPipe.Event do
-  defstruct destination: :nowhere,
+  defstruct destination: "nowhere",
             app: %{},
             shop: %{},
             token: %{},
             object: nil,
             callback: nil,
-            action: :none,
+            action: "none",
             assigns: %{},
             response: nil
 
   @type callback :: (ShopifyAPI.AuthToken.t(), t() -> any())
 
   @type t :: %__MODULE__{
-          destination: atom(),
+          destination: String.t(),
           token: map(),
           object: any(),
           callback: nil | callback(),
-          action: atom() | String.t(),
+          action: String.t(),
           assigns: map(),
           response: any()
         }

--- a/lib/shopify_api/event_pipe/event_queue.ex
+++ b/lib/shopify_api/event_pipe/event_queue.ex
@@ -1,6 +1,7 @@
 defmodule ShopifyAPI.EventPipe.EventQueue do
   require Logger
   alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.EventPipe.Event
 
   @retry_timer 250
 
@@ -9,33 +10,34 @@ defmodule ShopifyAPI.EventPipe.EventQueue do
 
   options: [max_retries: #] or any Exq valid enqueue option.
   """
+  @spec enqueue(Event.t(), keyword()) :: {:ok} | {:error, String.t()}
   def enqueue(event, opts \\ [])
 
-  def enqueue(%{destination: :application} = event, opts),
+  def enqueue(%Event{destination: "application"} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.ApplicationWorker, event, opts)
 
-  def enqueue(%{destination: :shopify, object: %{fulfillment: %{}}} = event, opts),
+  def enqueue(%Event{destination: "shopify", object: %{fulfillment: %{}}} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.FulfillmentWorker, event, opts)
 
-  def enqueue(%{destination: :shopify, object: %{inventory_level: %{}}} = event, opts),
+  def enqueue(%Event{destination: "shopify", object: %{inventory_level: %{}}} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.InventoryLevelWorker, event, opts)
 
-  def enqueue(%{destination: :shopify, object: %{location: %{}}} = event, opts),
+  def enqueue(%Event{destination: "shopify", object: %{location: %{}}} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.LocationWorker, event, opts)
 
-  def enqueue(%{destination: :shopify, object: %{metafield: %{}}} = event, opts),
+  def enqueue(%Event{destination: "shopify", object: %{metafield: %{}}} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.MetafieldWorker, event, opts)
 
-  def enqueue(%{destination: :shopify, object: %{product: %{}}} = event, opts),
+  def enqueue(%Event{destination: "shopify", object: %{product: %{}}} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.ProductWorker, event, opts)
 
-  def enqueue(%{destination: :shopify, object: %{tender_transaction: _}} = event, opts),
+  def enqueue(%Event{destination: "shopify", object: %{tender_transaction: _}} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.TenderTransactionWorker, event, opts)
 
-  def enqueue(%{destination: :shopify, object: %{transaction: %{}}} = event, opts),
+  def enqueue(%Event{destination: "shopify", object: %{transaction: %{}}} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.TransactionWorker, event, opts)
 
-  def enqueue(%{destination: :shopify, object: %{variant: %{}}} = event, opts),
+  def enqueue(%Event{destination: "shopify", object: %{variant: %{}}} = event, opts),
     do: enqueue_event(ShopifyAPI.EventPipe.VariantWorker, event, opts)
 
   def enqueue(event, _opts) do

--- a/lib/shopify_api/event_pipe/fulfillment_worker.ex
+++ b/lib/shopify_api/event_pipe/fulfillment_worker.ex
@@ -3,9 +3,10 @@ defmodule ShopifyAPI.EventPipe.FulfillmentWorker do
   Worker for processing Fulfillments
   """
   import ShopifyAPI.EventPipe.Worker
+  alias ShopifyAPI.EventPipe.Event
   alias ShopifyAPI.REST.Fulfillment
 
-  def perform(%{action: "create", object: _, token: _} = event) do
+  def perform(%Event{action: "create", object: _, token: _} = event) do
     execute_action(event, fn token,
                              %{object: %{fulfillment: %{order_id: order_id}} = fulfillment} ->
       Fulfillment.create(token, order_id, fulfillment)

--- a/lib/shopify_api/event_pipe/inventory_level_worker.ex
+++ b/lib/shopify_api/event_pipe/inventory_level_worker.ex
@@ -4,9 +4,10 @@ defmodule ShopifyAPI.EventPipe.InventoryLevelWorker do
   """
   require Logger
   import ShopifyAPI.EventPipe.Worker
+  alias ShopifyAPI.EventPipe.Event
   alias ShopifyAPI.REST.InventoryLevel
 
-  def perform(%{action: "set", object: _, token: _} = event) do
+  def perform(%Event{action: "set", object: _, token: _} = event) do
     execute_action(event, fn token, %{object: level} -> InventoryLevel.set(token, level) end)
   end
 end

--- a/lib/shopify_api/event_pipe/location_worker.ex
+++ b/lib/shopify_api/event_pipe/location_worker.ex
@@ -4,8 +4,9 @@ defmodule ShopifyAPI.EventPipe.LocationWorker do
   """
   require Logger
   import ShopifyAPI.EventPipe.Worker
+  alias ShopifyAPI.EventPipe.Event
   alias ShopifyAPI.REST.Location
 
-  def perform(%{action: "all", object: _, token: _} = event),
+  def perform(%Event{action: "all", object: _, token: _} = event),
     do: execute_action(event, fn token, _ -> Location.all(token) end)
 end

--- a/lib/shopify_api/event_pipe/metafield_worker.ex
+++ b/lib/shopify_api/event_pipe/metafield_worker.ex
@@ -6,21 +6,22 @@ defmodule ShopifyAPI.EventPipe.MetafieldWorker do
   """
   require Logger
   import ShopifyAPI.EventPipe.Worker
+  alias ShopifyAPI.EventPipe.Event
   alias ShopifyAPI.REST.Metafield
 
-  def perform(%{action: "create", object: _, token: _} = event) do
+  def perform(%Event{action: "create", object: _, token: _} = event) do
     execute_action(event, fn token, %{object: %{metafield: metafield, type: type, id: id}} ->
       Metafield.create(token, type, id, %{metafield: metafield})
     end)
   end
 
-  def perform(%{action: "update", object: _, token: _} = event) do
+  def perform(%Event{action: "update", object: _, token: _} = event) do
     execute_action(event, fn token, %{object: %{metafield: metafield, type: type, id: id}} ->
       Metafield.update(token, type, id, %{metafield: metafield})
     end)
   end
 
-  def perform(%{action: "get", object: _, token: _} = event) do
+  def perform(%Event{action: "get", object: _, token: _} = event) do
     execute_action(event, fn token, %{object: %{metafield: %{type: type, id: id}}} ->
       Metafield.all(token, type, id)
     end)

--- a/lib/shopify_api/event_pipe/product_worker.ex
+++ b/lib/shopify_api/event_pipe/product_worker.ex
@@ -4,15 +4,16 @@ defmodule ShopifyAPI.EventPipe.ProductWorker do
   """
   require Logger
   import ShopifyAPI.EventPipe.Worker
+  alias ShopifyAPI.EventPipe.Event
   alias ShopifyAPI.REST.Product
 
-  def perform(%{action: "create", object: _, token: _} = event),
+  def perform(%Event{action: "create", object: _, token: _} = event),
     do: execute_action(event, fn token, %{object: product} -> Product.create(token, product) end)
 
-  def perform(%{action: "update", object: _, token: _} = event),
+  def perform(%Event{action: "update", object: _, token: _} = event),
     do: execute_action(event, fn token, %{object: product} -> Product.update(token, product) end)
 
-  def perform(%{action: "get", object: _, token: _} = event),
+  def perform(%Event{action: "get", object: _, token: _} = event),
     do:
       execute_action(event, fn token, %{object: %{product: %{id: id}}} ->
         Product.get(token, id)

--- a/lib/shopify_api/event_pipe/tender_transactions_worker.ex
+++ b/lib/shopify_api/event_pipe/tender_transactions_worker.ex
@@ -3,9 +3,10 @@ defmodule ShopifyAPI.EventPipe.TenderTransactionWorker do
   Worker for processing Tender Transactions
   """
   import ShopifyAPI.EventPipe.Worker
+  alias ShopifyAPI.EventPipe.Event
   alias ShopifyAPI.REST.TenderTransaction
 
-  def perform(%{action: "all", token: _} = event) do
+  def perform(%Event{action: "all", token: _} = event) do
     execute_action(event, fn token, %{} ->
       TenderTransaction.all(token)
     end)

--- a/lib/shopify_api/event_pipe/transaction_worker.ex
+++ b/lib/shopify_api/event_pipe/transaction_worker.ex
@@ -3,9 +3,10 @@ defmodule ShopifyAPI.EventPipe.TransactionWorker do
   Worker for processing Transactions
   """
   import ShopifyAPI.EventPipe.Worker
+  alias ShopifyAPI.EventPipe.Event
   alias ShopifyAPI.REST.Transaction
 
-  def perform(%{action: "create", object: _, token: _} = event) do
+  def perform(%Event{action: "create", object: _, token: _} = event) do
     execute_action(event, fn token, %{object: transaction} ->
       Transaction.create(token, transaction)
     end)

--- a/lib/shopify_api/event_pipe/variant_worker.ex
+++ b/lib/shopify_api/event_pipe/variant_worker.ex
@@ -4,14 +4,15 @@ defmodule ShopifyAPI.EventPipe.VariantWorker do
   """
   require Logger
   import ShopifyAPI.EventPipe.Worker
+  alias ShopifyAPI.EventPipe.Event
   alias ShopifyAPI.REST.Variant
 
-  def perform(%{action: "create", object: _, token: _} = event) do
+  def perform(%Event{action: "create", object: _, token: _} = event) do
     execute_action(event, fn token, %{object: %{variant: %{product_id: product_id}} = variant} ->
       Variant.create(token, product_id, variant)
     end)
   end
 
-  def perform(%{action: "update", object: _, token: _} = event),
+  def perform(%Event{action: "update", object: _, token: _} = event),
     do: execute_action(event, fn token, %{object: variant} -> Variant.update(token, variant) end)
 end

--- a/lib/shopify_api/middleware/event_struct_coercer.ex
+++ b/lib/shopify_api/middleware/event_struct_coercer.ex
@@ -9,8 +9,9 @@ defmodule ShopifyAPI.Middleware.EventStructCoercer do
   alias ShopifyAPI.EventPipe.Event
 
   def before_work(%Pipeline{assigns: %{job: %{args: args} = job}} = pipeline) do
-    event = struct(Event, args)
-    Pipeline.assign(pipeline, :job, %{job | args: event})
+    events = Enum.map(args, fn event -> struct(Event, event) end)
+
+    Pipeline.assign(pipeline, :job, %{job | args: events})
   end
 
   def after_processed_work(pipeline), do: pipeline

--- a/lib/shopify_api/middleware/event_struct_coercer.ex
+++ b/lib/shopify_api/middleware/event_struct_coercer.ex
@@ -1,0 +1,18 @@
+defmodule ShopifyAPI.Middleware.EventStructCoercer do
+  @moduledoc """
+  Takes in an event and turns it into a struct. Allows for better typing on workers.
+  """
+
+  @behaviour Exq.Middleware.Behaviour
+
+  alias Exq.Middleware.Pipeline
+  alias ShopifyAPI.EventPipe.Event
+
+  def before_work(%Pipeline{assigns: %{job: %{args: args} = job}} = pipeline) do
+    event = Map.merge(%Event{}, args)
+    Pipeline.assign(pipeline, :job, %{job | args: event})
+  end
+
+  def after_processed_work(pipeline), do: pipeline
+  def after_failed_work(pipeline), do: pipeline
+end

--- a/lib/shopify_api/middleware/event_struct_coercer.ex
+++ b/lib/shopify_api/middleware/event_struct_coercer.ex
@@ -11,7 +11,7 @@ defmodule ShopifyAPI.Middleware.EventStructCoercer do
   def before_work(%Pipeline{assigns: %{job: %{args: args} = job}} = pipeline) do
     events =
       Enum.map(args, fn
-        %{description: _, action: _, token: _} = event -> struct(Event, event)
+        %{destination: _, action: _, token: _} = event -> struct(Event, event)
         non_event -> non_event
       end)
 

--- a/lib/shopify_api/middleware/event_struct_coercer.ex
+++ b/lib/shopify_api/middleware/event_struct_coercer.ex
@@ -9,7 +9,7 @@ defmodule ShopifyAPI.Middleware.EventStructCoercer do
   alias ShopifyAPI.EventPipe.Event
 
   def before_work(%Pipeline{assigns: %{job: %{args: args} = job}} = pipeline) do
-    event = Map.merge(%Event{}, args)
+    event = struct(Event, args)
     Pipeline.assign(pipeline, :job, %{job | args: event})
   end
 

--- a/lib/shopify_api/middleware/event_struct_coercer.ex
+++ b/lib/shopify_api/middleware/event_struct_coercer.ex
@@ -9,7 +9,11 @@ defmodule ShopifyAPI.Middleware.EventStructCoercer do
   alias ShopifyAPI.EventPipe.Event
 
   def before_work(%Pipeline{assigns: %{job: %{args: args} = job}} = pipeline) do
-    events = Enum.map(args, fn event -> struct(Event, event) end)
+    events =
+      Enum.map(args, fn
+        %{description: _, action: _, token: _} = event -> struct(Event, event)
+        non_event -> non_event
+      end)
 
     Pipeline.assign(pipeline, :job, %{job | args: events})
   end

--- a/lib/shopify_api/plugs/webhook.ex
+++ b/lib/shopify_api/plugs/webhook.ex
@@ -33,7 +33,7 @@ defmodule ShopifyAPI.Plugs.Webhook do
 
   defp generate_event(conn) do
     %Event{
-      destination: :client,
+      destination: "client",
       app: conn.assigns.app,
       shop: Map.get(conn.assigns, :shop),
       action: conn.assigns.shopify_event,

--- a/lib/shopify_api/router.ex
+++ b/lib/shopify_api/router.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.Router do
 
   alias Plug.Conn
   alias ShopifyAPI.{App, AuthToken, AuthTokenServer, ConnHelpers}
-  alias ShopifyAPI.EventPipe.EventQueue
+  alias ShopifyAPI.EventPipe.{Event, EventQueue}
 
   plug(:match)
   plug(:dispatch)
@@ -55,8 +55,8 @@ defmodule ShopifyAPI.Router do
   end
 
   defp enqueue_post_install(token) do
-    EventQueue.enqueue(%{
-      destination: :application,
+    EventQueue.enqueue(%Event{
+      destination: "application",
       token: token,
       action: "post_install"
     })

--- a/test/shopify_api/middlewere/event_struct_coercer_test.exs
+++ b/test/shopify_api/middlewere/event_struct_coercer_test.exs
@@ -1,0 +1,63 @@
+defmodule ShopifyAPI.Middleware.EventStructCoercerTest do
+  use ExUnit.Case
+
+  alias Exq.Middleware.Pipeline
+  alias ShopifyAPI.EventPipe.Event
+  alias ShopifyAPI.Middleware.EventStructCoercer
+
+  defp build_pipeline(args) when is_list(args) do
+    %Pipeline{
+      assigns: %{
+        job: %{
+          args: args
+        }
+      }
+    }
+  end
+
+  defp build_pipeline(arg), do: build_pipeline([arg])
+
+  test "converts a map into an event" do
+    pipe =
+      %{destination: "somewhere", action: "anything", token: %{}}
+      |> build_pipeline
+      |> EventStructCoercer.before_work()
+
+    assert ^pipe =
+             build_pipeline(%Event{destination: "somewhere", action: "anything", token: %{}})
+  end
+
+  test "converts a list of maps into events" do
+    pipe =
+      [
+        %{destination: "somewhere", action: "anything", token: %{}},
+        %{destination: "nowhere", action: "nothing", token: %{}}
+      ]
+      |> build_pipeline
+      |> EventStructCoercer.before_work()
+
+    assert ^pipe =
+             build_pipeline([
+               %Event{destination: "somewhere", action: "anything", token: %{}},
+               %Event{destination: "nowhere", action: "nothing", token: %{}}
+             ])
+  end
+
+  test "non events skip coercion" do
+    pipe =
+      [
+        {:not_an_event},
+        %{type: "not and event"},
+        %{destination: "is_event", action: "action", token: %{}}
+      ]
+      |> build_pipeline
+      |> EventStructCoercer.before_work()
+
+    assert ^pipe =
+             build_pipeline([
+               {:not_an_event},
+               %{type: "not and event"},
+               %Event{destination: "is_event", action: "action", token: %{}}
+             ])
+  end
+end

--- a/test/shopify_api/plugs/webhook_test.exs
+++ b/test/shopify_api/plugs/webhook_test.exs
@@ -62,7 +62,7 @@ defmodule ShopifyAPI.Plugs.WebhookTest do
       app: @app,
       assigns: %{},
       callback: nil,
-      destination: :client,
+      destination: "client",
       object: %{"app" => @app.name, "shop" => @shop.domain},
       shop: @shop,
       token: %{}


### PR DESCRIPTION
Formerly we had destinations and action as atom before getting onto the queue. But they would dequeue as strings. Make destinations and actions strings from the beginning for consistency. Additionally add middlewere to transform events into %Events{} for better typing. 
This should only break dialyzer as events off of the queue are already strings. 