### PR TITLE
Derive Jason.Encoder for EventPipe.Event struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add support for serializing `%ShopifyAPI.EventPipe.Event{}` structs with Jason.
+
 ## 0.4.0
 
 - Add BackgroundJobBehaviour to allow configure the job runner

--- a/lib/shopify_api/event_pipe/event.ex
+++ b/lib/shopify_api/event_pipe/event.ex
@@ -1,4 +1,5 @@
 defmodule ShopifyAPI.EventPipe.Event do
+  @derive Jason.Encoder
   defstruct destination: "nowhere",
             app: %{},
             shop: %{},


### PR DESCRIPTION
This allows `Event` instances to be serialized with the `Jason` library, similarly to the `Shop`, `AuthToken`, and `App` structs.