### PR TITLE
Log call limits for requests

### DIFF
--- a/lib/shopify_api/call_limit.ex
+++ b/lib/shopify_api/call_limit.ex
@@ -1,0 +1,32 @@
+defmodule ShopifyAPI.CallLimit do
+  @moduledoc """
+  Responsible for handling ShopifyAPI call limits in a HTTPoison.Response
+  """
+  @shopify_call_limit_header "X-Shopify-Shop-Api-Call-Limit"
+  @over_limit_status_code 429
+  # API Overlimit error code
+  def limit_header_or_status_code(%{status_code: @over_limit_status_code()}),
+    do: :over_limit
+
+  def limit_header_or_status_code(%{headers: headers}),
+    do: Enum.find(headers, fn header -> elem(header, 0) == @shopify_call_limit_header end)
+
+  def limit_header_or_status_code(_conn), do: nil
+
+  def get_api_call_limit(nil), do: nil
+
+  def get_api_call_limit(:over_limit), do: 0
+
+  def get_api_call_limit(header) do
+    # comes in the form "1/40": 1 taken of 40
+    header
+    |> get_value_from_header
+    |> String.split("/")
+    |> Enum.map(&String.to_integer/1)
+    |> calculate_available
+  end
+
+  defp get_value_from_header({_, value}), do: value
+
+  defp calculate_available([used, total]), do: total - used
+end

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.Request do
   require Logger
 
   alias HTTPoison.{AsyncResponse, Error, Response}
-  alias ShopifyAPI.{AuthToken, Throttled, ThrottleServer}
+  alias ShopifyAPI.{AuthToken, CallLimit, Throttled, ThrottleServer}
 
   @default_api_version "2019-04"
 
@@ -51,7 +51,7 @@ defmodule ShopifyAPI.REST.Request do
             request(action, url, body, headers, recv_timeout: @http_receive_timeout)
           end)
 
-        log_request(action, url, time)
+        log_request(action, url, time, response)
 
         case response do
           {:ok, %{status_code: status} = response} when status >= 200 and status < 300 ->
@@ -71,11 +71,18 @@ defmodule ShopifyAPI.REST.Request do
     )
   end
 
-  defp log_request(action, url, time) do
+  defp log_request(action, url, time, response) do
     Logger.debug(fn ->
       module = __MODULE__ |> to_string() |> String.trim_leading("Elixir.")
       action = action |> to_string() |> String.upcase()
-      "#{module} #{action} #{url} [#{div(time, 1_000)}ms]"
+
+      call_limit =
+        case response do
+          {:ok, http_response} -> CallLimit.limit_header_or_status_code(http_response)
+          _ -> nil
+        end
+
+      "#{module} #{action} #{url} (#{call_limit}) [#{div(time, 1_000)}ms]"
     end)
   end
 

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -76,15 +76,17 @@ defmodule ShopifyAPI.REST.Request do
       module = __MODULE__ |> to_string() |> String.trim_leading("Elixir.")
       action = action |> to_string() |> String.upcase()
 
-      call_limit =
-        case response do
-          {:ok, http_response} -> CallLimit.limit_header_or_status_code(http_response)
-          _ -> nil
-        end
-
-      "#{module} #{action} #{url} (#{call_limit}) [#{div(time, 1_000)}ms]"
+      "#{module} #{action} #{url} (#{call_limit(response)}) [#{div(time, 1_000)}ms]"
     end)
   end
+
+  defp call_limit({:ok, response}) do
+    response
+    |> CallLimit.limit_header_or_status_code()
+    |> CallLimit.get_api_call_limit()
+  end
+
+  defp call_limit(_), do: nil
 
   def process_response_body(body), do: Poison.decode(body)
 

--- a/lib/shopify_api/throttle_server.ex
+++ b/lib/shopify_api/throttle_server.ex
@@ -2,12 +2,11 @@ defmodule ShopifyAPI.ThrottleServer do
   use GenServer
   require Logger
 
-  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.{AuthToken, CallLimit}
 
   @name :shopify_api_throttle_server
-  @shopify_call_limit_header "X-Shopify-Shop-Api-Call-Limit"
-  @over_limit_status_code 429
 
+  @spec start_link(any) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(_opts) do
     Logger.info(fn -> "Starting #{__MODULE__} ..." end)
 
@@ -31,36 +30,10 @@ defmodule ShopifyAPI.ThrottleServer do
 
   def update_api_call_limit(http_response, token) do
     http_response
-    |> limit_header_or_status_code
-    |> get_api_call_limit
+    |> CallLimit.limit_header_or_status_code()
+    |> CallLimit.get_api_call_limit()
     |> set(token)
   end
-
-  # API Overlimit error code
-  defp limit_header_or_status_code(%{status_code: @over_limit_status_code()}),
-    do: :over_limit
-
-  defp limit_header_or_status_code(%{headers: headers}),
-    do: Enum.find(headers, fn header -> elem(header, 0) == @shopify_call_limit_header end)
-
-  defp limit_header_or_status_code(_conn), do: nil
-
-  defp get_api_call_limit(nil), do: nil
-
-  defp get_api_call_limit(:over_limit), do: 0
-
-  defp get_api_call_limit(header) do
-    # comes in the form "1/40": 1 taken of 40
-    header
-    |> get_value_from_header
-    |> String.split("/")
-    |> Enum.map(&String.to_integer/1)
-    |> calculate_available
-  end
-
-  defp get_value_from_header({_, value}), do: value
-
-  defp calculate_available([used, total]), do: total - used
 
   #
   # Callbacks

--- a/test/shopify_api/call_limit_test.exs
+++ b/test/shopify_api/call_limit_test.exs
@@ -1,0 +1,53 @@
+defmodule ShopifyAPI.CallLimitTest do
+  use ExUnit.Case
+
+  alias ShopifyAPI.CallLimit
+
+  alias HTTPoison.{Error, Response}
+
+  describe "limit_header_or_status_code/1" do
+    test "pulls the call_limit header out of response headers" do
+      call_limit_header = {"X-Shopify-Shop-Api-Call-Limit", "32/50"}
+      response = %Response{headers: [{"foo", "bar"}, call_limit_header, {"bat", "biz"}]}
+
+      assert CallLimit.limit_header_or_status_code(response) == call_limit_header
+    end
+
+    test "returns :over_limit on status code 429" do
+      call_limit_header = {"X-Shopify-Shop-Api-Call-Limit", "32/50"}
+
+      response = %Response{
+        status_code: 429,
+        headers: [{"foo", "bar"}, call_limit_header, {"bat", "biz"}]
+      }
+
+      assert CallLimit.limit_header_or_status_code(response) == :over_limit
+    end
+
+    test "returns nil if no call limit header" do
+      response = %Response{headers: [{"foo", "bar"}]}
+
+      assert CallLimit.limit_header_or_status_code(response) == nil
+    end
+
+    test "returns nil on error" do
+      assert CallLimit.limit_header_or_status_code(%Error{}) == nil
+    end
+  end
+
+  describe "get_api_call_limit/1" do
+    test "calculates the call limit from the header" do
+      header = {"X-Shopify-Shop-Api-Call-Limit", "32/50"}
+
+      assert CallLimit.get_api_call_limit(header) == 18
+    end
+
+    test "returns 0 for :over_limit" do
+      assert CallLimit.get_api_call_limit(:over_limit) == 0
+    end
+
+    test "nil passes through" do
+      assert CallLimit.get_api_call_limit(nil) == nil
+    end
+  end
+end


### PR DESCRIPTION
* Move call limit logic out of ThrottleServer and into CallLimit module.
* Include call limit in Request module's logging

Future step is to add this to :telemetry. But I want to look into some of the details around that before I put that in. 