### PR TITLE
Simplify implementation/responsibilities of REST.Request

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -134,7 +134,7 @@
         {Credo.Check.Refactor.AppendSingleItem, false},
         {Credo.Check.Refactor.VariableRebinding, false},
         {Credo.Check.Warning.MapGetUnsafePass, false},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse},
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
 
         #
         # Deprecated checks (these will be deleted after a grace period)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Refactor `ShopifyAPI.REST.Request`, extract underlying `get`/`post`/`put`/`delete` to `ShopifyAPI.REST`.
+- Correct examples for `ShopifyAPI.REST.Collect`.
+
 ## 0.4.1
 
 - Add support for serializing `%ShopifyAPI.EventPipe.Event{}` structs with Jason.

--- a/lib/shopify_api/rest.ex
+++ b/lib/shopify_api/rest.ex
@@ -1,0 +1,34 @@
+defmodule ShopifyAPI.REST do
+  @moduledoc """
+  Provides core REST actions for interacting with the Shopify API.
+  Uses an `AuthToken` for authorization and request rate limiting.
+
+  Please don't use this module directly. Instead prefer the higher-level modules
+  implementing appropriate resource endpoints, such as `ShopifyAPI.REST.Product`
+  """
+
+  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.REST.Request
+
+  @doc false
+  def get(%AuthToken{} = auth, path) do
+    Request.perform(auth, :get, path)
+  end
+
+  @doc false
+  def post(%AuthToken{} = auth, path, object \\ %{}) do
+    with {:ok, body} <- Poison.encode(object),
+         do: Request.perform(auth, :post, path, body)
+  end
+
+  @doc false
+  def put(%AuthToken{} = auth, path, object) do
+    with {:ok, body} <- Poison.encode(object),
+         do: Request.perform(auth, :put, path, body)
+  end
+
+  @doc false
+  def delete(%AuthToken{} = auth, path) do
+    Request.perform(auth, :delete, path)
+  end
+end

--- a/lib/shopify_api/rest/access_scope.ex
+++ b/lib/shopify_api/rest/access_scope.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.AccessScope do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all access scopes associated with the access token.
@@ -14,5 +14,5 @@ defmodule ShopifyAPI.REST.AccessScope do
       iex> ShopifyAPI.REST.AccessScope.get(auth)
       {:ok, %{ "access_scopes" => [] }}
   """
-  def get(%AuthToken{} = auth), do: Request.get(auth, "oauth/access_scopes.json")
+  def get(%AuthToken{} = auth), do: REST.get(auth, "oauth/access_scopes.json")
 end

--- a/lib/shopify_api/rest/application_charge.ex
+++ b/lib/shopify_api/rest/application_charge.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.ApplicationCharge do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Create an application charge.
@@ -18,7 +18,7 @@ defmodule ShopifyAPI.REST.ApplicationCharge do
         %AuthToken{} = auth,
         %{application_charge: %{}} = application_charge
       ),
-      do: Request.post(auth, "application_charges.json", application_charge)
+      do: REST.post(auth, "application_charges.json", application_charge)
 
   @doc """
   Get a single application charge.
@@ -29,7 +29,7 @@ defmodule ShopifyAPI.REST.ApplicationCharge do
       {:ok, { "application_charge" => %{} }}
   """
   def get(%AuthToken{} = auth, application_charge_id),
-    do: Request.get(auth, "application_charges/#{application_charge_id}.json")
+    do: REST.get(auth, "application_charges/#{application_charge_id}.json")
 
   @doc """
   Get a list of all application charges.
@@ -39,7 +39,7 @@ defmodule ShopifyAPI.REST.ApplicationCharge do
       iex> ShopifyAPI.REST.ApplicationCharge.all(auth)
       {:ok, { "application_charges" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "application_charges.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "application_charges.json")
 
   @doc """
   Active an application charge.
@@ -53,7 +53,7 @@ defmodule ShopifyAPI.REST.ApplicationCharge do
         %AuthToken{} = auth,
         %{application_charge: %{id: application_charge_id}} = application_charge
       ) do
-    Request.post(
+    REST.post(
       auth,
       "application_charges/#{application_charge_id}/activate.json",
       application_charge

--- a/lib/shopify_api/rest/application_credit.ex
+++ b/lib/shopify_api/rest/application_credit.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.ApplicationCredit do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Create an application credit.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.ApplicationCredit do
       {:ok, { "application_credit" => %{} }}
   """
   def create(%AuthToken{} = auth, %{application_credit: %{}} = application_credit),
-    do: Request.post(auth, "application_credits.json", application_credit)
+    do: REST.post(auth, "application_credits.json", application_credit)
 
   @doc """
   Get a single application credit.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.ApplicationCredit do
       {:ok, { "application_credit" => %{} }}
   """
   def get(%AuthToken{} = auth, application_credit_id),
-    do: Request.get(auth, "application_credits/#{application_credit_id}.json")
+    do: REST.get(auth, "application_credits/#{application_credit_id}.json")
 
   @doc """
   Get a list of all application credits.
@@ -36,5 +36,5 @@ defmodule ShopifyAPI.REST.ApplicationCredit do
       iex> ShopifyAPI.REST.ApplicationCredit.all(auth)
       {:ok, { "application_credits" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "application_credits.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "application_credits.json")
 end

--- a/lib/shopify_api/rest/asset.ex
+++ b/lib/shopify_api/rest/asset.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.Asset do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a single theme asset.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.Asset do
       {:ok, { "asset" => %{} }}
   """
   def get(%AuthToken{} = auth, theme_id, params),
-    do: Request.get(auth, "themes/#{theme_id}/assets.json?" <> URI.encode_query(params))
+    do: REST.get(auth, "themes/#{theme_id}/assets.json?" <> URI.encode_query(params))
 
   @doc """
   Return a list of all theme assets.
@@ -25,7 +25,7 @@ defmodule ShopifyAPI.REST.Asset do
       iex> ShopifyAPI.REST.Asset.all(auth, theme_id)
       {:ok, { "assets" => [] }}
   """
-  def all(%AuthToken{} = auth, theme_id), do: Request.get(auth, "themes/#{theme_id}/assets.json")
+  def all(%AuthToken{} = auth, theme_id), do: REST.get(auth, "themes/#{theme_id}/assets.json")
 
   @doc """
   Update a theme asset.
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.Asset do
     {:ok, %{ "asset" => %{} }}
   """
   def update(%AuthToken{} = auth, theme_id, asset),
-    do: Request.put(auth, "themes/#{theme_id}/assets.json", asset)
+    do: REST.put(auth, "themes/#{theme_id}/assets.json", asset)
 
   @doc """
   Delete a theme asset.
@@ -47,7 +47,7 @@ defmodule ShopifyAPI.REST.Asset do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, theme_id, params),
-    do: Request.delete(auth, "themes/#{theme_id}/assets.json?" <> URI.encode_query(params))
+    do: REST.delete(auth, "themes/#{theme_id}/assets.json?" <> URI.encode_query(params))
 
   @doc """
   Create a new theme asset.

--- a/lib/shopify_api/rest/carrier_service.ex
+++ b/lib/shopify_api/rest/carrier_service.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.CarrierService do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all carrier services.
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.CarrierService do
       iex> ShopifyAPI.REST.CarrierService.all(auth)
       {:ok, { "carrier_services" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "carrier_services.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "carrier_services.json")
 
   @doc """
   Get a single carrier service.
@@ -25,7 +25,7 @@ defmodule ShopifyAPI.REST.CarrierService do
       {:ok, { "carrier_service" => %{} }}
   """
   def get(%AuthToken{} = auth, carrier_service_id),
-    do: Request.get(auth, "carrier_services/#{carrier_service_id}.json")
+    do: REST.get(auth, "carrier_services/#{carrier_service_id}.json")
 
   @doc """
   Create a carrier service.
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.CarrierService do
       {:ok, { "carrier_service" => %{} }}
   """
   def create(%AuthToken{} = auth, %{carrier_service: %{}} = carrier_service),
-    do: Request.post(auth, "carrier_services.json", carrier_service)
+    do: REST.post(auth, "carrier_services.json", carrier_service)
 
   @doc """
   Update a carrier service.
@@ -50,7 +50,7 @@ defmodule ShopifyAPI.REST.CarrierService do
         %AuthToken{} = auth,
         %{carrier_service: %{id: carrier_service_id}} = carrier_service
       ),
-      do: Request.put(auth, "carrier_services/#{carrier_service_id}.json", carrier_service)
+      do: REST.put(auth, "carrier_services/#{carrier_service_id}.json", carrier_service)
 
   @doc """
   Delete a carrier service.
@@ -61,5 +61,5 @@ defmodule ShopifyAPI.REST.CarrierService do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, carrier_service_id),
-    do: Request.delete(auth, "carrier_services/#{carrier_service_id}.json")
+    do: REST.delete(auth, "carrier_services/#{carrier_service_id}.json")
 end

--- a/lib/shopify_api/rest/collect.ex
+++ b/lib/shopify_api/rest/collect.ex
@@ -11,8 +11,8 @@ defmodule ShopifyAPI.REST.Collect do
 
   ## Example
 
-      iex> ShopifyAPI.REST.REST.add(auth)
-      {:ok, { "collect" => %{} }}
+      iex> ShopifyAPI.REST.Collect.add(auth, %{collect: collect})
+      {:ok, %{ "collect" => %{} }}
   """
   def add(%AuthToken{} = auth, %{collect: %{}} = collect),
     do: REST.post(auth, "collects.json", collect)
@@ -22,8 +22,8 @@ defmodule ShopifyAPI.REST.Collect do
 
   ## Example
 
-      iex> ShopifyAPI.REST.Delete(auth, string)
-      {:ok, 200 }
+      iex> ShopifyAPI.REST.Collect.delete(auth, collect_id)
+      {:ok, 200}
   """
   def delete(%AuthToken{} = auth, collect_id),
     do: REST.delete(auth, "collects/#{collect_id}.json")
@@ -33,8 +33,8 @@ defmodule ShopifyAPI.REST.Collect do
 
   ## Example
 
-      iex> ShopifyAPI.REST.Get(auth)
-      {:ok, { "collects" => [] }}
+      iex> ShopifyAPI.REST.Collect.all(auth)
+      {:ok, %{ "collects" => [] }}
   """
   def all(%AuthToken{} = auth), do: REST.get(auth, "collects.json")
 
@@ -43,8 +43,8 @@ defmodule ShopifyAPI.REST.Collect do
 
   ## Example
 
-      iex> ShopifyAPI.REST.Count(auth)
-      {:ok, { "count": integer }}
+      iex> ShopifyAPI.REST.Collect.count(auth)
+      {:ok, %{ "count" => 123 }}
   """
   def count(%AuthToken{} = auth), do: REST.get(auth, "collects/count.json")
 
@@ -53,8 +53,8 @@ defmodule ShopifyAPI.REST.Collect do
 
   ## Example
 
-      iex> ShopifyAPI.REST.Get(auth, string)
-      {:ok, { "collect" => %{} }}
+      iex> ShopifyAPI.REST.Collect.get(auth, id)
+      {:ok, %{ "collect" => %{} }}
   """
   def get(%AuthToken{} = auth, collect_id), do: REST.get(auth, "collects/#{collect_id}.json")
 end

--- a/lib/shopify_api/rest/collect.ex
+++ b/lib/shopify_api/rest/collect.ex
@@ -4,18 +4,18 @@ defmodule ShopifyAPI.REST.Collect do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Add a product to custom collection.
 
   ## Example
 
-      iex> ShopifyAPI.REST.Request.add(auth)
+      iex> ShopifyAPI.REST.REST.add(auth)
       {:ok, { "collect" => %{} }}
   """
   def add(%AuthToken{} = auth, %{collect: %{}} = collect),
-    do: Request.post(auth, "collects.json", collect)
+    do: REST.post(auth, "collects.json", collect)
 
   @doc """
   Remove a product from a custom collection.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.Collect do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, collect_id),
-    do: Request.delete(auth, "collects/#{collect_id}.json")
+    do: REST.delete(auth, "collects/#{collect_id}.json")
 
   @doc """
   Get list of all collects.
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.Collect do
       iex> ShopifyAPI.REST.Get(auth)
       {:ok, { "collects" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "collects.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "collects.json")
 
   @doc """
   Get a count of collects.
@@ -46,7 +46,7 @@ defmodule ShopifyAPI.REST.Collect do
       iex> ShopifyAPI.REST.Count(auth)
       {:ok, { "count": integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "collects/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "collects/count.json")
 
   @doc """
   Get a specific collect.
@@ -56,5 +56,5 @@ defmodule ShopifyAPI.REST.Collect do
       iex> ShopifyAPI.REST.Get(auth, string)
       {:ok, { "collect" => %{} }}
   """
-  def get(%AuthToken{} = auth, collect_id), do: Request.get(auth, "collects/#{collect_id}.json")
+  def get(%AuthToken{} = auth, collect_id), do: REST.get(auth, "collects/#{collect_id}.json")
 end

--- a/lib/shopify_api/rest/custom_collection.ex
+++ b/lib/shopify_api/rest/custom_collection.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.CustomCollection do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a list of all the custom collections.
@@ -13,7 +13,7 @@ defmodule ShopifyAPI.REST.CustomCollection do
       iex> ShopifyAPI.REST.CustomCollection.all(token)
       {:ok, %{ "custom_collections" => %{} }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "admin/custom_collections.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "admin/custom_collections.json")
 
   @doc """
   Get a count of all custom collections.
@@ -22,7 +22,7 @@ defmodule ShopifyAPI.REST.CustomCollection do
       iex> ShopifyAPI.REST.CustomCollection.count(token)
       {:ok, { "count": integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "custom_collections/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "custom_collections/count.json")
 
   @doc """
   Return a single custom collection.
@@ -32,7 +32,7 @@ defmodule ShopifyAPI.REST.CustomCollection do
       {:ok, %{ "custom_collections" => %{} }}
   """
   def get(%AuthToken{} = auth, custom_collection_id),
-    do: Request.get(auth, "custom_collections/#{custom_collection_id}.json")
+    do: REST.get(auth, "custom_collections/#{custom_collection_id}.json")
 
   @doc """
   Create a custom collection.
@@ -42,7 +42,7 @@ defmodule ShopifyAPI.REST.CustomCollection do
       {:ok, %{ "custom_collection" => %{} }}
   """
   def create(%AuthToken{} = auth, %{custom_collection: %{}} = custom_collection),
-    do: Request.post(auth, "custom_collections.json", custom_collection)
+    do: REST.post(auth, "custom_collections.json", custom_collection)
 
   @doc """
   Update an existing custom collection.
@@ -55,7 +55,7 @@ defmodule ShopifyAPI.REST.CustomCollection do
         %AuthToken{} = auth,
         %{custom_collection: %{id: custom_collection_id}} = custom_collection
       ),
-      do: Request.put(auth, "custom_collections/#{custom_collection_id}.json", custom_collection)
+      do: REST.put(auth, "custom_collections/#{custom_collection_id}.json", custom_collection)
 
   @doc """
   Delete a custom collection.
@@ -65,5 +65,5 @@ defmodule ShopifyAPI.REST.CustomCollection do
       {:ok, %{ "response": 200 }}
   """
   def delete(%AuthToken{} = auth, custom_collection_id),
-    do: Request.delete(auth, "custom_collections/#{custom_collection_id}.json")
+    do: REST.delete(auth, "custom_collections/#{custom_collection_id}.json")
 end

--- a/lib/shopify_api/rest/customer.ex
+++ b/lib/shopify_api/rest/customer.ex
@@ -5,7 +5,7 @@ defmodule ShopifyAPI.REST.Customer do
 
   require Logger
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Returns all the customers.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.Customer do
       iex> ShopifyAPI.REST.Customer.all(auth)
       {:ok, {"customers" => []}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "customers.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "customers.json")
 
   @doc """
   Return a single customer.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.Customer do
       {:ok, {"customer" = > %{}}
   """
   def get(%AuthToken{} = auth, customer_id),
-    do: Request.get(auth, "customers/#{customer_id}.json")
+    do: REST.get(auth, "customers/#{customer_id}.json")
 
   @doc """
   Return a customers that match supplied query.
@@ -52,7 +52,7 @@ defmodule ShopifyAPI.REST.Customer do
       {:ok, {"customer" => %{}}
   """
   def create(%AuthToken{} = auth, %{customer: %{}} = customer),
-    do: Request.post(auth, "customers.json", customer)
+    do: REST.post(auth, "customers.json", customer)
 
   @doc """
   Updates a customer.
@@ -63,7 +63,7 @@ defmodule ShopifyAPI.REST.Customer do
       {:ok, {"customer" => %{}}
   """
   def update(%AuthToken{} = auth, %{customer: %{id: customer_id}} = customer),
-    do: Request.put(auth, "customers/#{customer_id}.json", customer)
+    do: REST.put(auth, "customers/#{customer_id}.json", customer)
 
   @doc """
   Create an account activation URL.
@@ -77,7 +77,7 @@ defmodule ShopifyAPI.REST.Customer do
         %AuthToken{} = auth,
         %{customer: %{id: customer_id}} = customer
       ),
-      do: Request.post(auth, "customers/#{customer_id}/account_activation.json", customer)
+      do: REST.post(auth, "customers/#{customer_id}/account_activation.json", customer)
 
   @doc """
   Send an account invite to customer.
@@ -88,7 +88,7 @@ defmodule ShopifyAPI.REST.Customer do
       {:ok, {"customer_invite" => %{}}
   """
   def send_invite(%AuthToken{} = auth, customer_id),
-    do: Request.post(auth, "customers/#{customer_id}/send_invite.json")
+    do: REST.post(auth, "customers/#{customer_id}/send_invite.json")
 
   @doc """
   Delete a customer.
@@ -99,7 +99,7 @@ defmodule ShopifyAPI.REST.Customer do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, customer_id),
-    do: Request.delete(auth, "customers/#{customer_id}")
+    do: REST.delete(auth, "customers/#{customer_id}")
 
   @doc """
   Return a count of all customers.
@@ -109,7 +109,7 @@ defmodule ShopifyAPI.REST.Customer do
       iex> ShopifyAPI.REST.Customer.count(auth)
       {:ok, {"count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "customers/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "customers/count.json")
 
   @doc """
   Return all orders from a customer.
@@ -120,7 +120,7 @@ defmodule ShopifyAPI.REST.Customer do
       {:ok, {"orders" => [] }}
   """
   def get_orders(%AuthToken{} = auth, customer_id),
-    do: Request.get(auth, "customers/#{customer_id}/orders.json")
+    do: REST.get(auth, "customers/#{customer_id}/orders.json")
 
   @doc """
   Search for customers that match a supplied query
@@ -136,5 +136,5 @@ defmodule ShopifyAPI.REST.Customer do
   %{"query" => "Bob country:Canada"} - returns all customers with an address in Canada and the name "Bob"
   """
   def search(%AuthToken{} = auth, params),
-    do: Request.get(auth, "customers/search.json?" <> URI.encode_query(params))
+    do: REST.get(auth, "customers/search.json?" <> URI.encode_query(params))
 end

--- a/lib/shopify_api/rest/customer_address.ex
+++ b/lib/shopify_api/rest/customer_address.ex
@@ -5,7 +5,7 @@ defmodule ShopifyAPI.REST.CustomerAddress do
 
   require Logger
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all addresses for a customer.
@@ -16,7 +16,7 @@ defmodule ShopifyAPI.REST.CustomerAddress do
       {:ok, %{ "addresses" => [] }}
   """
   def all(%AuthToken{} = auth, customer_id),
-    do: Request.get(auth, "customers/#{customer_id}/addresses.json")
+    do: REST.get(auth, "customers/#{customer_id}/addresses.json")
 
   @doc """
   Return a single address for a customer.
@@ -27,7 +27,7 @@ defmodule ShopifyAPI.REST.CustomerAddress do
       {:ok, %{ "customer_address" => %{} }}
   """
   def get(%AuthToken{} = auth, customer_id, address_id),
-    do: Request.get(auth, "customers/#{customer_id}/addresses/#{address_id}.json")
+    do: REST.get(auth, "customers/#{customer_id}/addresses/#{address_id}.json")
 
   @doc """
   Create a new address for a customer.
@@ -38,7 +38,7 @@ defmodule ShopifyAPI.REST.CustomerAddress do
       {:ok, %{ "customer_address" => %{} }}
   """
   def create(%AuthToken{} = auth, customer_id, %{address: %{}} = address),
-    do: Request.post(auth, "customers/#{customer_id}/addresses.json", address)
+    do: REST.post(auth, "customers/#{customer_id}/addresses.json", address)
 
   @doc """
   Update an existing customer address.
@@ -53,7 +53,7 @@ defmodule ShopifyAPI.REST.CustomerAddress do
         customer_id,
         %{address: %{id: address_id}} = address
       ) do
-    Request.put(
+    REST.put(
       auth,
       "customers/#{customer_id}/addresses/#{address_id}.json",
       address
@@ -69,7 +69,7 @@ defmodule ShopifyAPI.REST.CustomerAddress do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, customer_id, address_id),
-    do: Request.delete(auth, "customers/#{customer_id}/addresses/#{address_id}.json")
+    do: REST.delete(auth, "customers/#{customer_id}/addresses/#{address_id}.json")
 
   @doc """
   Perform bulk operations for multiple customer addresses.
@@ -99,7 +99,7 @@ defmodule ShopifyAPI.REST.CustomerAddress do
         customer_id,
         %{address: %{id: address_id}} = address
       ) do
-    Request.put(
+    REST.put(
       auth,
       "customers/#{customer_id}/addresses/#{address_id}/default.json",
       address

--- a/lib/shopify_api/rest/discount_code.ex
+++ b/lib/shopify_api/rest/discount_code.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Create a discount code.
@@ -18,7 +18,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
         %AuthToken{} = auth,
         %{discount_code: %{price_rule_id: price_rule_id}} = discount_code
       ) do
-    Request.post(auth, "price_rules/#{price_rule_id}/discount_codes.json", discount_code)
+    REST.post(auth, "price_rules/#{price_rule_id}/discount_codes.json", discount_code)
   end
 
   @doc """
@@ -34,7 +34,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
         price_rule_id,
         %{discount_code: %{id: discount_code_id}} = discount_code
       ) do
-    Request.put(
+    REST.put(
       auth,
       "price_rules/#{price_rule_id}/discount_codes/#{discount_code_id}.json",
       discount_code
@@ -50,7 +50,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
       {:ok, { "discount_codes" => [] }}
   """
   def all(%AuthToken{} = auth, price_rule_id) do
-    Request.get(auth, "price_rules/#{price_rule_id}/discount_codes.json")
+    REST.get(auth, "price_rules/#{price_rule_id}/discount_codes.json")
   end
 
   @doc """
@@ -62,7 +62,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
       {:ok, { "discount_code" => %{} }}
   """
   def get(%AuthToken{} = auth, price_rule_id, discount_code_id),
-    do: Request.get(auth, "price_rules/#{price_rule_id}/discount_codes/#{discount_code_id}.json")
+    do: REST.get(auth, "price_rules/#{price_rule_id}/discount_codes/#{discount_code_id}.json")
 
   @doc """
   Retrieve the location of a discount code.
@@ -73,7 +73,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
       {:ok, { "location" => "" }}
   """
   def query(%AuthToken{} = auth, coupon_code),
-    do: Request.get(auth, "discount_codes/lookup.json?code=#{coupon_code}")
+    do: REST.get(auth, "discount_codes/lookup.json?code=#{coupon_code}")
 
   @doc """
   Delete a discount code.
@@ -84,8 +84,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
       {:ok, 204 }}
   """
   def delete(%AuthToken{} = auth, price_rule_id, discount_code_id),
-    do:
-      Request.delete(auth, "price_rules/#{price_rule_id}/discount_codes/#{discount_code_id}.json")
+    do: REST.delete(auth, "price_rules/#{price_rule_id}/discount_codes/#{discount_code_id}.json")
 
   @doc """
   Creates a discount code creation job.
@@ -96,7 +95,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
       {:ok, "discount_codes" => [] }}
   """
   def create_batch(auth, price_rule_id, %{discount_codes: []} = discount_codes),
-    do: Request.post(auth, "price_rules/#{price_rule_id}/batch.json", discount_codes)
+    do: REST.post(auth, "price_rules/#{price_rule_id}/batch.json", discount_codes)
 
   @doc """
   Get a discount code creation job.
@@ -107,7 +106,7 @@ defmodule ShopifyAPI.REST.DiscountCode do
       {:ok, "discount_code_creation" => %{} }
   """
   def get_batch(%AuthToken{} = auth, price_rule_id, batch_id),
-    do: Request.get(auth, "price_rules/#{price_rule_id}/batch/#{batch_id}.json")
+    do: REST.get(auth, "price_rules/#{price_rule_id}/batch/#{batch_id}.json")
 
   @doc """
   Return a list of discount codes for a discount code creation job.
@@ -118,5 +117,5 @@ defmodule ShopifyAPI.REST.DiscountCode do
       {:ok, "discount_codes" => [] }
   """
   def all_batch(%AuthToken{} = auth, price_rule_id, batch_id),
-    do: Request.get(auth, "price_rules/#{price_rule_id}/batch/#{batch_id}/discount_code.json")
+    do: REST.get(auth, "price_rules/#{price_rule_id}/batch/#{batch_id}/discount_code.json")
 end

--- a/lib/shopify_api/rest/draft_order.ex
+++ b/lib/shopify_api/rest/draft_order.ex
@@ -5,7 +5,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
   This resource contains methods for working with draft orders in Shopify
   """
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Create a new draft order with the provided attributes
@@ -16,7 +16,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
       {:ok, %{"draft_order" => %{...}}}
   """
   def create(%AuthToken{} = auth, %{draft_order: %{}} = draft_order),
-    do: Request.post(auth, "draft_orders.json", draft_order)
+    do: REST.post(auth, "draft_orders.json", draft_order)
 
   @doc """
   Update a draft order
@@ -35,7 +35,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
       }
   """
   def update(%AuthToken{} = auth, %{draft_order: %{id: draft_order_id}} = draft_order),
-    do: Request.put(auth, "draft_orders/#{draft_order_id}.json", draft_order)
+    do: REST.put(auth, "draft_orders/#{draft_order_id}.json", draft_order)
 
   @doc """
   Retrieve a list of all draft orders
@@ -45,7 +45,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
       iex> ShopifyAPI.REST.DraftOrder.all(auth)
       {:ok, %{"draft_orders" => []}}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "draft_orders.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "draft_orders.json")
 
   @doc """
   Retrieve a specific draft order
@@ -56,7 +56,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
       {:ok, %{"draft_order" => %{...}}}
   """
   def get(%AuthToken{} = auth, draft_order_id),
-    do: Request.get(auth, "draft_orders/#{draft_order_id}.json")
+    do: REST.get(auth, "draft_orders/#{draft_order_id}.json")
 
   @doc """
   Retrieve a count of all draft orders
@@ -66,7 +66,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
       iex> ShopifyAPI.REST.DraftOrder.count(auth)
       {:ok, %{count: integer}}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "draft_orders/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "draft_orders/count.json")
 
   @doc """
   Send an invoice for a draft order
@@ -100,7 +100,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
         %{draft_order_invoice: %{}} = draft_order_invoice
       ),
       do:
-        Request.post(
+        REST.post(
           auth,
           "draft_orders/#{draft_order_id}/send_invoice.json",
           draft_order_invoice
@@ -115,7 +115,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
       {:ok, %{}}
   """
   def delete(%AuthToken{} = auth, draft_order_id),
-    do: Request.delete(auth, "draft_orders/#{draft_order_id}.json")
+    do: REST.delete(auth, "draft_orders/#{draft_order_id}.json")
 
   @doc """
   Complete a draft order
@@ -132,7 +132,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
   """
   def complete(%AuthToken{} = auth, draft_order_id, params \\ %{}),
     do:
-      Request.put(
+      REST.put(
         auth,
         "draft_orders/#{draft_order_id}/complete.json?" <> URI.encode_query(params),
         %{}

--- a/lib/shopify_api/rest/event.ex
+++ b/lib/shopify_api/rest/event.ex
@@ -6,7 +6,7 @@ defmodule ShopifyAPI.REST.Event do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all Events.
@@ -16,7 +16,7 @@ defmodule ShopifyAPI.REST.Event do
       iex> ShopifyAPI.REST.Event.all(auth)
       {:ok, { "events" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "events.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "events.json")
 
   @doc """
   Get a single event.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.Event do
       iex> ShopifyAPI.REST.Event.get(auth, integer)
       {:ok, { "event" => %{} }}
   """
-  def get(%AuthToken{} = auth, event_id), do: Request.get(auth, "events/#{event_id}.json")
+  def get(%AuthToken{} = auth, event_id), do: REST.get(auth, "events/#{event_id}.json")
 
   @doc """
   Get a count of all Events.
@@ -36,5 +36,5 @@ defmodule ShopifyAPI.REST.Event do
       iex> ShopifyAPI.REST.Event.count(auth)
       {:ok, { "events" => integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "events/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "events/count.json")
 end

--- a/lib/shopify_api/rest/fulfillment.ex
+++ b/lib/shopify_api/rest/fulfillment.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all fulfillments.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
       {:ok, { "fulfillments" => [] }}
   """
   def all(%AuthToken{} = auth, order_id),
-    do: Request.get(auth, "orders/#{order_id}/fulfillments.json")
+    do: REST.get(auth, "orders/#{order_id}/fulfillments.json")
 
   @doc """
   Return a count of all fulfillments.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
       {:ok, { "count" => integer }}
   """
   def count(%AuthToken{} = auth, order_id),
-    do: Request.get(auth, "orders/#{order_id}/fulfillments/count.json")
+    do: REST.get(auth, "orders/#{order_id}/fulfillments/count.json")
 
   @doc """
   Get a single fulfillment.
@@ -37,7 +37,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
       {:ok, { "fulfillment" => %{} }}
   """
   def get(%AuthToken{} = auth, order_id, fulfillment_id),
-    do: Request.get(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}.json")
+    do: REST.get(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}.json")
 
   @doc """
   Create a new fulfillment.
@@ -48,7 +48,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
       {:ok, { "fulfillment" => %{} }}
   """
   def create(%AuthToken{} = auth, order_id, %{fulfillment: %{}} = fulfillment),
-    do: Request.post(auth, "orders/#{order_id}/fulfillments.json", fulfillment)
+    do: REST.post(auth, "orders/#{order_id}/fulfillments.json", fulfillment)
 
   @doc """
   Update an existing fulfillment.
@@ -63,7 +63,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
         order_id,
         %{fulfillment: %{id: fulfillment_id}} = fulfillment
       ),
-      do: Request.put(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}.json", fulfillment)
+      do: REST.put(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}.json", fulfillment)
 
   @doc """
   Complete a fulfillment.
@@ -74,7 +74,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
       {:ok, { "fulfillment" => %{} }}
   """
   def complete(%AuthToken{} = auth, order_id, %{fulfillment: %{id: fulfillment_id}} = fulfillment) do
-    Request.post(
+    REST.post(
       auth,
       "orders/#{order_id}/fulfillments/#{fulfillment_id}/complete.json",
       fulfillment
@@ -90,7 +90,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
       {:ok, { "fulfillment" => %{} }}
   """
   def open(%AuthToken{} = auth, order_id, %{fulfillment: %{id: fulfillment_id}} = fulfillment) do
-    Request.post(
+    REST.post(
       auth,
       "orders/#{order_id}/fulfillments/#{fulfillment_id}/open.json",
       fulfillment
@@ -106,7 +106,7 @@ defmodule ShopifyAPI.REST.Fulfillment do
       {:ok, { "fulfillment" => %{} }}
   """
   def cancel(%AuthToken{} = auth, order_id, %{fulfillment: %{id: fulfillment_id}} = fulfillment) do
-    Request.post(
+    REST.post(
       auth,
       "orders/#{order_id}/fulfillments/#{fulfillment_id}/cancel.json",
       fulfillment

--- a/lib/shopify_api/rest/fulfillment_event.ex
+++ b/lib/shopify_api/rest/fulfillment_event.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.FulfillmentEvent do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all fulfillment events.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.FulfillmentEvent do
       {:ok, { "fulfillment_events" => [] }}
   """
   def all(%AuthToken{} = auth, order_id, fulfillment_id),
-    do: Request.get(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}/events.json")
+    do: REST.get(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}/events.json")
 
   @doc """
   Get a single fulfillment event.
@@ -27,7 +27,7 @@ defmodule ShopifyAPI.REST.FulfillmentEvent do
   """
   def get(%AuthToken{} = auth, order_id, fulfillment_id, event_id),
     do:
-      Request.get(
+      REST.get(
         auth,
         "orders/#{order_id}/fulfillments/#{fulfillment_id}/events/#{event_id}.json"
       )
@@ -45,7 +45,7 @@ defmodule ShopifyAPI.REST.FulfillmentEvent do
         order_id,
         %{fulfillment_event: %{id: fulfillment_id}} = fulfillment_event
       ) do
-    Request.post(
+    REST.post(
       auth,
       "orders/#{order_id}/fulfillments/#{fulfillment_id}/events.json",
       fulfillment_event
@@ -61,7 +61,7 @@ defmodule ShopifyAPI.REST.FulfillmentEvent do
       {:ok,  200 }
   """
   def delete(%AuthToken{} = auth, order_id, fulfillment_id, event_id) do
-    Request.delete(
+    REST.delete(
       auth,
       "orders/#{order_id}/fulfillments/#{fulfillment_id}/events/#{event_id}.json"
     )

--- a/lib/shopify_api/rest/fulfillment_service.ex
+++ b/lib/shopify_api/rest/fulfillment_service.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.FulfillmentService do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all the fulfillment services.
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.FulfillmentService do
       iex> ShopifyAPI.REST.FulfillmentService.all(auth)
       {:ok, { "fulfillment_services" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "fulfillment_services.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "fulfillment_services.json")
 
   @doc """
   Get a single fulfillment service.
@@ -25,7 +25,7 @@ defmodule ShopifyAPI.REST.FulfillmentService do
       {:ok, { "fulfillment_service" => %{} }}
   """
   def get(%AuthToken{} = auth, fulfillment_service_id),
-    do: Request.get(auth, "fulfillment_services/#{fulfillment_service_id}.json")
+    do: REST.get(auth, "fulfillment_services/#{fulfillment_service_id}.json")
 
   @doc """
   Create a new fulfillment service.
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.FulfillmentService do
       {:ok, { "fulfillment_service" => %{} }}
   """
   def create(%AuthToken{} = auth, %{fulfillment_service: %{}} = fulfillment_service),
-    do: Request.post(auth, "fulfillment_services.json", fulfillment_service)
+    do: REST.post(auth, "fulfillment_services.json", fulfillment_service)
 
   @doc """
   Update an existing fulfillment service.
@@ -50,7 +50,7 @@ defmodule ShopifyAPI.REST.FulfillmentService do
         %AuthToken{} = auth,
         %{fulfillment_service: %{id: fulfillment_service_id}} = fulfillment_service
       ) do
-    Request.put(auth, "fulfillment_services/#{fulfillment_service_id}.json", fulfillment_service)
+    REST.put(auth, "fulfillment_services/#{fulfillment_service_id}.json", fulfillment_service)
   end
 
   @doc """
@@ -62,5 +62,5 @@ defmodule ShopifyAPI.REST.FulfillmentService do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, fulfillment_service_id),
-    do: Request.delete(auth, "fulfillment_services/#{fulfillment_service_id}.json")
+    do: REST.delete(auth, "fulfillment_services/#{fulfillment_service_id}.json")
 end

--- a/lib/shopify_api/rest/inventory_item.ex
+++ b/lib/shopify_api/rest/inventory_item.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.InventoryItem do
   """
   require Logger
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of inventory items.
@@ -30,7 +30,7 @@ defmodule ShopifyAPI.REST.InventoryItem do
       {:ok, { "inventory_item" => %{} }}
   """
   def get(%AuthToken{} = auth, inventory_item_id),
-    do: Request.get(auth, "inventory_items/#{inventory_item_id}.json")
+    do: REST.get(auth, "inventory_items/#{inventory_item_id}.json")
 
   @doc """
   Update an existing inventory item.
@@ -41,5 +41,5 @@ defmodule ShopifyAPI.REST.InventoryItem do
       {:ok, { "inventory_item" => %{} }}
   """
   def update(%AuthToken{} = auth, %{inventory_item: %{id: inventory_item_id}} = inventory_item),
-    do: Request.put(auth, "inventory_items/#{inventory_item_id}.json", inventory_item)
+    do: REST.put(auth, "inventory_items/#{inventory_item_id}.json", inventory_item)
 end

--- a/lib/shopify_api/rest/inventory_level.ex
+++ b/lib/shopify_api/rest/inventory_level.ex
@@ -3,7 +3,7 @@ defmodule ShopifyAPI.REST.InventoryLevel do
   ShopifyAPI REST API InventoryLevel resource
   """
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of inventory levels.
@@ -13,7 +13,7 @@ defmodule ShopifyAPI.REST.InventoryLevel do
       iex> ShopifyAPI.REST.InventoryLevel.all(auth)
       {:ok, { "inventory_level" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "inventory_levels.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "inventory_levels.json")
 
   @doc """
   Sets the inventory level for an inventory item at a location.
@@ -29,7 +29,7 @@ defmodule ShopifyAPI.REST.InventoryLevel do
           inventory_level: %{inventory_item_id: _, location_id: _, available: _} = inventory_level
         }
       ) do
-    Request.post(auth, "inventory_levels/set.json", inventory_level)
+    REST.post(auth, "inventory_levels/set.json", inventory_level)
   end
 
   @doc """
@@ -41,7 +41,7 @@ defmodule ShopifyAPI.REST.InventoryLevel do
       {:ok, 200 }}
   """
   def delete(%AuthToken{} = auth, inventory_item_id, location_id) do
-    Request.delete(
+    REST.delete(
       auth,
       "inventory_levels.json?inventory_item_id=#{inventory_item_id}&location_id=#{location_id}"
     )

--- a/lib/shopify_api/rest/location.ex
+++ b/lib/shopify_api/rest/location.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.Location do
   """
   require Logger
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of locations.
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.Location do
       iex> ShopifyAPI.REST.Location.all(auth)
       {:ok, { "locations" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "locations.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "locations.json")
 
   @doc """
   Return a single location.
@@ -25,7 +25,7 @@ defmodule ShopifyAPI.REST.Location do
     {:ok, %{ "location" => %{} }}
   """
   def get(%AuthToken{} = auth, location_id),
-    do: Request.get(auth, "locations/#{location_id}.json")
+    do: REST.get(auth, "locations/#{location_id}.json")
 
   @doc """
   Return a count of locations.
@@ -35,7 +35,7 @@ defmodule ShopifyAPI.REST.Location do
     iex> ShopifyAPI.REST.Location.count(auth)
     {:ok, %{ "count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "locations/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "locations/count.json")
 
   @doc """
   Returns a list of inventory levels for a location.
@@ -46,5 +46,5 @@ defmodule ShopifyAPI.REST.Location do
     {:ok, %{ "inventory_levels" => %{} }}
   """
   def inventory_levels(%AuthToken{} = auth, location_id),
-    do: Request.get(auth, "locations/#{location_id}/inventory_levels.json")
+    do: REST.get(auth, "locations/#{location_id}/inventory_levels.json")
 end

--- a/lib/shopify_api/rest/marketing_event.ex
+++ b/lib/shopify_api/rest/marketing_event.ex
@@ -5,7 +5,7 @@ defmodule ShopifyAPI.REST.MarketingEvent do
 
   require Logger
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all marketing events.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.MarketingEvent do
       iex> ShopifyAPI.REST.MarketingEvent.all(auth)
       {:ok, { "marketing_events" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "marketing_events.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "marketing_events.json")
 
   @doc """
   Get a count of all marketing events.
@@ -25,7 +25,7 @@ defmodule ShopifyAPI.REST.MarketingEvent do
       iex> ShopifyAPI.REST.MarketingEvent.count(auth)
       {:ok, { "count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "marketing_events/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "marketing_events/count.json")
 
   @doc """
   Get a single marketing event.
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.MarketingEvent do
       {:ok, { "marketing_event" => %{} }}
   """
   def get(%AuthToken{} = auth, marketing_event_id),
-    do: Request.get(auth, "marketing_events/#{marketing_event_id}.json")
+    do: REST.get(auth, "marketing_events/#{marketing_event_id}.json")
 
   @doc """
   Create a marketing event.
@@ -50,7 +50,7 @@ defmodule ShopifyAPI.REST.MarketingEvent do
         %AuthToken{} = auth,
         %{marketing_event: %{id: marketing_event_id}} = marketing_event
       ),
-      do: Request.post(auth, "marketing_events/#{marketing_event_id}.json", marketing_event)
+      do: REST.post(auth, "marketing_events/#{marketing_event_id}.json", marketing_event)
 
   @doc """
   Update a marketing event.
@@ -64,7 +64,7 @@ defmodule ShopifyAPI.REST.MarketingEvent do
         %AuthToken{} = auth,
         %{marketing_event: %{id: marketing_event_id}} = marketing_event
       ),
-      do: Request.put(auth, "marketing_events/#{marketing_event_id}.json", marketing_event)
+      do: REST.put(auth, "marketing_events/#{marketing_event_id}.json", marketing_event)
 
   @doc """
   Delete a marketing event.
@@ -75,7 +75,7 @@ defmodule ShopifyAPI.REST.MarketingEvent do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, marketing_event_id),
-    do: Request.delete(auth, "marketing_events/#{marketing_event_id}.json")
+    do: REST.delete(auth, "marketing_events/#{marketing_event_id}.json")
 
   @doc """
   Creates a marketing engagements on a marketing event.

--- a/lib/shopify_api/rest/metafield.ex
+++ b/lib/shopify_api/rest/metafield.ex
@@ -10,7 +10,7 @@ defmodule ShopifyAPI.REST.Metafield do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a list of all metafields that belong to a resource.
@@ -24,10 +24,10 @@ defmodule ShopifyAPI.REST.Metafield do
     {:ok, %{ "metafields" => [] }}
   """
   def all(%AuthToken{} = auth, params \\ %{}),
-    do: Request.get(auth, "metafields.json?" <> URI.encode_query(params))
+    do: REST.get(auth, "metafields.json?" <> URI.encode_query(params))
 
   def all(%AuthToken{} = auth, type, resource_id, params \\ %{}),
-    do: Request.get(auth, resource_path(type, resource_id) <> "?" <> URI.encode_query(params))
+    do: REST.get(auth, resource_path(type, resource_id) <> "?" <> URI.encode_query(params))
 
   @doc """
   Return a count of metafields that belong to a Shop resource.
@@ -37,7 +37,7 @@ defmodule ShopifyAPI.REST.Metafield do
     iex> ShopifyAPI.REST.Metafields.count(token)
     {:ok, %{ "count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "metafields/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "metafields/count.json")
 
   @doc """
   Return a count that belong to a resource and its metafields.
@@ -48,7 +48,7 @@ defmodule ShopifyAPI.REST.Metafield do
     {:ok, %{ "count" => integer }}
   """
   def count(%AuthToken{} = auth, type, resource_id),
-    do: Request.get(auth, resource_path(type, resource_id))
+    do: REST.get(auth, resource_path(type, resource_id))
 
   @doc """
   Return a list of metafields for a resource by it's ID.
@@ -59,7 +59,7 @@ defmodule ShopifyAPI.REST.Metafield do
     {:ok, %{ "metafields" => [] }}
   """
   def get(%AuthToken{} = auth, type, resource_id),
-    do: Request.get(auth, resource_path(type, resource_id))
+    do: REST.get(auth, resource_path(type, resource_id))
 
   @doc """
   Creates a new metafield.
@@ -69,7 +69,7 @@ defmodule ShopifyAPI.REST.Metafield do
     iex> ShopifyAPI.REST.Metafields.create(auth, map)
     {:ok, %{ "metafield" => %{} }}
   """
-  def create(%AuthToken{} = auth, metafield), do: Request.post(auth, "metafields.json", metafield)
+  def create(%AuthToken{} = auth, metafield), do: REST.post(auth, "metafields.json", metafield)
 
   @doc """
   Creates a new metafield for a resource.
@@ -80,7 +80,7 @@ defmodule ShopifyAPI.REST.Metafield do
     {:ok, %{ "metafield" => %{} }}
   """
   def create(%AuthToken{} = auth, type, resource_id, metafield),
-    do: Request.post(auth, resource_path(type, resource_id), metafield)
+    do: REST.post(auth, resource_path(type, resource_id), metafield)
 
   @doc """
   Update a metafield.
@@ -91,7 +91,7 @@ defmodule ShopifyAPI.REST.Metafield do
     {:ok, %{ "metafield" => %{} }}
   """
   def update(%AuthToken{} = auth, type, resource_id, %{metafield: %{id: id}} = metafield),
-    do: Request.put(auth, resource_path(type, resource_id, id), metafield)
+    do: REST.put(auth, resource_path(type, resource_id, id), metafield)
 
   @doc """
   Delete a metafield by its Metafield ID.
@@ -102,7 +102,7 @@ defmodule ShopifyAPI.REST.Metafield do
     {:ok, %{ "metafield" => %{} }}
   """
   def delete(%AuthToken{} = auth, metafield_id),
-    do: Request.delete(auth, resource_path(:metafield, metafield_id))
+    do: REST.delete(auth, resource_path(:metafield, metafield_id))
 
   ## Private
 

--- a/lib/shopify_api/rest/order.ex
+++ b/lib/shopify_api/rest/order.ex
@@ -2,14 +2,14 @@ defmodule ShopifyAPI.REST.Order do
   @moduledoc """
   """
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @shopify_per_page_max 250
 
   @doc """
     Return a single Order.
   """
-  def get(%AuthToken{} = auth, order_id), do: Request.get(auth, "orders/#{order_id}.json")
+  def get(%AuthToken{} = auth, order_id), do: REST.get(auth, "orders/#{order_id}.json")
 
   @doc """
     Return all of a shops Orders filtered by query parameters.
@@ -18,14 +18,14 @@ defmodule ShopifyAPI.REST.Order do
   iex> ShopifyAPI.REST.Order.all(auth, %{param1: "value", param2: "value2"})
   """
   def all(%AuthToken{} = auth, params \\ %{}),
-    do: Request.get(auth, "orders.json?" <> URI.encode_query(params))
+    do: REST.get(auth, "orders.json?" <> URI.encode_query(params))
 
   @doc """
     Delete an Order.
 
   iex> ShopifyAPI.REST.Order.delete(auth, order_id)
   """
-  def delete(%AuthToken{} = auth, order_id), do: Request.delete(auth, "orders/#{order_id}.json")
+  def delete(%AuthToken{} = auth, order_id), do: REST.delete(auth, "orders/#{order_id}.json")
 
   @doc """
     Create a new Order.
@@ -33,7 +33,7 @@ defmodule ShopifyAPI.REST.Order do
   iex> ShopifyAPI.REST.Order.create(auth, %Order{})
   """
   def create(%AuthToken{} = auth, %{order: %{}} = order),
-    do: Request.post(auth, "orders.json", order)
+    do: REST.post(auth, "orders.json", order)
 
   @doc """
     Update an Order.
@@ -41,7 +41,7 @@ defmodule ShopifyAPI.REST.Order do
   iex> ShopifyAPI.REST.Order.update(auth, order_id)
   """
   def update(%AuthToken{} = auth, %{order: %{id: order_id}} = order),
-    do: Request.put(auth, "orders/#{order_id}.json", order)
+    do: REST.put(auth, "orders/#{order_id}.json", order)
 
   @doc """
     Return a count of all Orders.
@@ -49,7 +49,7 @@ defmodule ShopifyAPI.REST.Order do
   iex> ShopifyAPI.REST.Order.get(token)
   {:ok, %{"count" => integer}}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "orders/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "orders/count.json")
 
   @doc """
     Close an Order.
@@ -57,14 +57,14 @@ defmodule ShopifyAPI.REST.Order do
   iex> ShopifyAPI.REST.Order.close(auth, order_id)
   """
   def close(%AuthToken{} = auth, order_id),
-    do: Request.post(auth, "orders/#{order_id}/close.json")
+    do: REST.post(auth, "orders/#{order_id}/close.json")
 
   @doc """
     Re-open a closed Order.
 
   iex> ShopifyAPI.REST.Order.open(auth, order_id)
   """
-  def open(%AuthToken{} = auth, order_id), do: Request.post(auth, "orders/#{order_id}/open.json")
+  def open(%AuthToken{} = auth, order_id), do: REST.post(auth, "orders/#{order_id}/open.json")
 
   @doc """
     Cancel an Order.
@@ -72,7 +72,7 @@ defmodule ShopifyAPI.REST.Order do
   iex> ShopifyAPI.REST.Order.cancel(auth, order_id)
   """
   def cancel(%AuthToken{} = auth, order_id),
-    do: Request.post(auth, "orders/#{order_id}/cancel.json")
+    do: REST.post(auth, "orders/#{order_id}/cancel.json")
 
   def max_per_page, do: @shopify_per_page_max
 end

--- a/lib/shopify_api/rest/price_rule.ex
+++ b/lib/shopify_api/rest/price_rule.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.PriceRule do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Create a price rule.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.PriceRule do
       {:ok, { "price_rule" => %{} }}
   """
   def create(%AuthToken{} = auth, %{price_rule: %{}} = price_rule),
-    do: Request.post(auth, "price_rules.json", price_rule)
+    do: REST.post(auth, "price_rules.json", price_rule)
 
   @doc """
   Update an existing price rule.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.PriceRule do
       {:ok, { "price_rule" => %{} }}
   """
   def update(%AuthToken{} = auth, %{price_rule: %{id: price_rule_id}} = price_rule),
-    do: Request.put(auth, "price_rules/#{price_rule_id}.json", price_rule)
+    do: REST.put(auth, "price_rules/#{price_rule_id}.json", price_rule)
 
   @doc """
   Return a list of all price rules.
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.PriceRule do
       iex> ShopifyAPI.REST.PriceRule.all(auth)
       {:ok, { "price_rules" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "price_rules.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "price_rules.json")
 
   @doc """
   Get a single price rule.
@@ -47,7 +47,7 @@ defmodule ShopifyAPI.REST.PriceRule do
       {:ok, { "price_rule" => %{} }}
   """
   def get(%AuthToken{} = auth, price_rule_id),
-    do: Request.get(auth, "price_rules/#{price_rule_id}.json")
+    do: REST.get(auth, "price_rules/#{price_rule_id}.json")
 
   @doc """
   Delete a price rule.
@@ -58,5 +58,5 @@ defmodule ShopifyAPI.REST.PriceRule do
       {:ok, 204 }}
   """
   def delete(%AuthToken{} = auth, price_rule_id),
-    do: Request.delete(auth, "price_rules/#{price_rule_id}.json")
+    do: REST.delete(auth, "price_rules/#{price_rule_id}.json")
 end

--- a/lib/shopify_api/rest/product.ex
+++ b/lib/shopify_api/rest/product.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.Product do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a list of all the products.
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.Product do
     iex> ShopifyAPI.REST.Product.all(auth)
     {:ok, %{ "products" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "products.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "products.json")
 
   @doc """
   Return a single product.
@@ -24,7 +24,7 @@ defmodule ShopifyAPI.REST.Product do
     iex> ShopifyAPI.REST.Product.get(auth, integer)
     {:ok, %{ "product" => %{} }}
   """
-  def get(%AuthToken{} = auth, product_id), do: Request.get(auth, "products/#{product_id}.json")
+  def get(%AuthToken{} = auth, product_id), do: REST.get(auth, "products/#{product_id}.json")
 
   @doc """
   Return a count of products.
@@ -34,7 +34,7 @@ defmodule ShopifyAPI.REST.Product do
     iex> ShopifyAPI.REST.Product.count(auth)
     {:ok, %{ "count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "products/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "products/count.json")
 
   @doc """
   Update a product.
@@ -48,7 +48,7 @@ defmodule ShopifyAPI.REST.Product do
     do: update(auth, %{product: Map.put(product, :id, product_id)})
 
   def update(%AuthToken{} = auth, %{product: %{id: product_id}} = product),
-    do: Request.put(auth, "products/#{product_id}.json", product)
+    do: REST.put(auth, "products/#{product_id}.json", product)
 
   @doc """
   Delete a product.
@@ -59,7 +59,7 @@ defmodule ShopifyAPI.REST.Product do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, product_id),
-    do: Request.delete(auth, "products/#{product_id}.json")
+    do: REST.delete(auth, "products/#{product_id}.json")
 
   @doc """
   Create a new product.
@@ -73,5 +73,5 @@ defmodule ShopifyAPI.REST.Product do
     do: create(auth, %{product: product})
 
   def create(%AuthToken{} = auth, %{product: %{}} = product),
-    do: Request.post(auth, "products.json", product)
+    do: REST.post(auth, "products.json", product)
 end

--- a/lib/shopify_api/rest/product_image.ex
+++ b/lib/shopify_api/rest/product_image.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.ProductImage do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all products images.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.ProductImage do
       {:ok, { "images" => [] }}
   """
   def all(%AuthToken{} = auth, product_id),
-    do: Request.get(auth, "products/#{product_id}/images.json")
+    do: REST.get(auth, "products/#{product_id}/images.json")
 
   @doc """
   Get a count of all product images.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.ProductImage do
       {:ok, { "count" => integer }}
   """
   def count(%AuthToken{} = auth, product_id),
-    do: Request.get(auth, "products/#{product_id}/images/count.json")
+    do: REST.get(auth, "products/#{product_id}/images/count.json")
 
   @doc """
   Get all images for a single product.
@@ -37,7 +37,7 @@ defmodule ShopifyAPI.REST.ProductImage do
       {:ok, { "image" => %{} }}
   """
   def get(%AuthToken{} = auth, product_id),
-    do: Request.get(auth, "products/#{product_id}/images.json")
+    do: REST.get(auth, "products/#{product_id}/images.json")
 
   @doc """
   Get a single product image.
@@ -48,7 +48,7 @@ defmodule ShopifyAPI.REST.ProductImage do
       {:ok, { "image" => %{} }}
   """
   def get(%AuthToken{} = auth, product_id, image_id),
-    do: Request.get(auth, "products/#{product_id}/images/#{image_id}.json")
+    do: REST.get(auth, "products/#{product_id}/images/#{image_id}.json")
 
   @doc """
   Create a new product image.
@@ -59,7 +59,7 @@ defmodule ShopifyAPI.REST.ProductImage do
       {:ok, { "image" => %{} }}
   """
   def create(%AuthToken{} = auth, product_id, %{image: %{}} = image),
-    do: Request.post(auth, "products/#{product_id}/images.json", image)
+    do: REST.post(auth, "products/#{product_id}/images.json", image)
 
   @doc """
   Update an existing product image.
@@ -70,7 +70,7 @@ defmodule ShopifyAPI.REST.ProductImage do
       {:ok, { "image" => %{} }}
   """
   def update(%AuthToken{} = auth, product_id, %{image: %{id: image_id}} = image),
-    do: Request.put(auth, "products/#{product_id}/images/#{image_id}.json", image)
+    do: REST.put(auth, "products/#{product_id}/images/#{image_id}.json", image)
 
   @doc """
   Delete a product image.
@@ -81,5 +81,5 @@ defmodule ShopifyAPI.REST.ProductImage do
       {:ok, 200 }}
   """
   def delete(%AuthToken{} = auth, product_id, image_id),
-    do: Request.delete(auth, "products/#{product_id}/images/#{image_id}.json")
+    do: REST.delete(auth, "products/#{product_id}/images/#{image_id}.json")
 end

--- a/lib/shopify_api/rest/recurring_application_charge.ex
+++ b/lib/shopify_api/rest/recurring_application_charge.ex
@@ -5,7 +5,7 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
 
   require Logger
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Create a recurring application charge.
@@ -19,7 +19,7 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
         %AuthToken{} = auth,
         %{recurring_application_charge: {}} = recurring_application_charge
       ) do
-    Request.post(auth, "recurring_application_charges.json", recurring_application_charge)
+    REST.post(auth, "recurring_application_charges.json", recurring_application_charge)
   end
 
   @doc """
@@ -31,7 +31,7 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
       {:ok, { "recurring_application_charge" => %{} }}
   """
   def get(%AuthToken{} = auth, recurring_application_charge_id),
-    do: Request.get(auth, "recurring_application_charges/#{recurring_application_charge_id}.json")
+    do: REST.get(auth, "recurring_application_charges/#{recurring_application_charge_id}.json")
 
   @doc """
   Get a list of all recurring application charges.
@@ -41,7 +41,7 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
       iex> ShopifyAPI.REST.RecurringApplicationCharge.all(auth)
       {:ok, { "recurring_application_charges" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "recurring_application_charges.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "recurring_application_charges.json")
 
   @doc """
   Activates a recurring application charge.
@@ -52,7 +52,7 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
       {:ok, { "recurring_application_charge" => %{} }}
   """
   def activate(%AuthToken{} = auth, recurring_application_charge_id) do
-    Request.post(
+    REST.post(
       auth,
       "recurring_application_charges/#{recurring_application_charge_id}/activate.json"
     )
@@ -68,7 +68,7 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
   """
   def cancel(%AuthToken{} = auth, recurring_application_charge_id),
     do:
-      Request.delete(
+      REST.delete(
         auth,
         "recurring_application_charges/#{recurring_application_charge_id}.json"
       )

--- a/lib/shopify_api/rest/refund.ex
+++ b/lib/shopify_api/rest/refund.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.Refund do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Return a list of all refunds for an order.
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.Refund do
       iex> ShopifyAPI.REST.Refund.all(auth, string)
       {:ok, { "refunds" => [] }}
   """
-  def all(%AuthToken{} = auth, order_id), do: Request.get(auth, "orders/#{order_id}/refunds.json")
+  def all(%AuthToken{} = auth, order_id), do: REST.get(auth, "orders/#{order_id}/refunds.json")
 
   @doc """
   Get a specific refund.
@@ -25,7 +25,7 @@ defmodule ShopifyAPI.REST.Refund do
       {:ok, { "refund" => %{} }}
   """
   def get(%AuthToken{} = auth, order_id, refund_id),
-    do: Request.get(auth, "orders/#{order_id}/refunds/#{refund_id}.json")
+    do: REST.get(auth, "orders/#{order_id}/refunds/#{refund_id}.json")
 
   @doc """
   Calculate a refund.
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.Refund do
       {:ok, { "refund" => %{} }}
   """
   def calculate(%AuthToken{} = auth, order_id, %{refund: %{}} = refund),
-    do: Request.post(auth, "orders/#{order_id}/refunds/calculate.json", refund)
+    do: REST.post(auth, "orders/#{order_id}/refunds/calculate.json", refund)
 
   @doc """
   Create a refund.
@@ -47,5 +47,5 @@ defmodule ShopifyAPI.REST.Refund do
       {:ok, { "refund" => %{} }}
   """
   def create(%AuthToken{} = auth, order_id, %{refund: %{}} = refund),
-    do: Request.post(auth, "orders/#{order_id}/refunds.json", refund)
+    do: REST.post(auth, "orders/#{order_id}/refunds.json", refund)
 end

--- a/lib/shopify_api/rest/report.ex
+++ b/lib/shopify_api/rest/report.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.Report do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a list of all reports.
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.Report do
       iex> ShopifyAPI.REST.Report.all(auth)
       {:ok, { "reports" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "reports.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "reports.json")
 
   @doc """
   Return a single report.
@@ -24,7 +24,7 @@ defmodule ShopifyAPI.REST.Report do
       iex> ShopifyAPI.REST.Report.get(auth, integer)
       {:ok, { "report" => %{} }}
   """
-  def get(%AuthToken{} = auth, report_id), do: Request.get(auth, "reports/#{report_id}.json")
+  def get(%AuthToken{} = auth, report_id), do: REST.get(auth, "reports/#{report_id}.json")
 
   @doc """
   Create a new report.
@@ -35,7 +35,7 @@ defmodule ShopifyAPI.REST.Report do
       {:ok, { "report" => %{} }}
   """
   def create(%AuthToken{} = auth, %{report: %{}} = report),
-    do: Request.post(auth, "reports.json", report)
+    do: REST.post(auth, "reports.json", report)
 
   @doc """
   Update a report.
@@ -46,7 +46,7 @@ defmodule ShopifyAPI.REST.Report do
       {:ok, { "report" => %{} }}
   """
   def update(%AuthToken{} = auth, %{report: %{id: report_id}} = report),
-    do: Request.put(auth, "reports/#{report_id}.json", report)
+    do: REST.put(auth, "reports/#{report_id}.json", report)
 
   @doc """
   Delete.
@@ -57,5 +57,5 @@ defmodule ShopifyAPI.REST.Report do
       {:ok, 200 }}
   """
   def delete(%AuthToken{} = auth, report_id),
-    do: Request.delete(auth, "reports/#{report_id}.json")
+    do: REST.delete(auth, "reports/#{report_id}.json")
 end

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -55,10 +55,12 @@ defmodule ShopifyAPI.REST.Request do
     response
   end
 
+  @impl true
   def process_request_options(opts) do
     Keyword.put_new(opts, :recv_timeout, @http_receive_timeout)
   end
 
+  @impl true
   def process_response_body(body) do
     Poison.decode(body)
   end

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -1,5 +1,10 @@
 defmodule ShopifyAPI.REST.Request do
-  @moduledoc false
+  @moduledoc """
+  The internal interface to Shopify's REST Admin API, built on HTTPoison.
+
+  Adds support for building URLs and authentication headers from an AuthToken,
+  as well as functionality to throttle/log requests and parse responses.
+  """
 
   use HTTPoison.Base
   require Logger

--- a/lib/shopify_api/rest/shop.ex
+++ b/lib/shopify_api/rest/shop.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.Shop do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a shop's configuration.
@@ -14,5 +14,5 @@ defmodule ShopifyAPI.REST.Shop do
       iex> ShopifyAPI.REST.Shop.get(auth)
       {:ok, { "shop" => %{} }}
   """
-  def get(%AuthToken{} = auth), do: Request.get(auth, "shop.json")
+  def get(%AuthToken{} = auth), do: REST.get(auth, "shop.json")
 end

--- a/lib/shopify_api/rest/smart_collection.ex
+++ b/lib/shopify_api/rest/smart_collection.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.SmartCollection do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a list of all SmartCollections.
@@ -13,7 +13,7 @@ defmodule ShopifyAPI.REST.SmartCollection do
       iex> ShopifyAPI.REST.SmartCollection.all(token)
       {:ok, %{ "smart_collections" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "admin/smart_collections.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "admin/smart_collections.json")
 
   @doc """
   Get a count of all SmartCollections.
@@ -22,7 +22,7 @@ defmodule ShopifyAPI.REST.SmartCollection do
       iex> ShopifyAPI.REST.SmartCollection.count(token)
       {:ok, { "count": integer }}
   """
-  def count(%AuthToken{} = auth), do: Request.get(auth, "smart_collections/count.json")
+  def count(%AuthToken{} = auth), do: REST.get(auth, "smart_collections/count.json")
 
   @doc """
   Return a single SmartCollection.
@@ -32,7 +32,7 @@ defmodule ShopifyAPI.REST.SmartCollection do
       {:ok, %{ "smart_collection" => %{} }}
   """
   def get(%AuthToken{} = auth, smart_collection_id),
-    do: Request.get(auth, "smart_collections/#{smart_collection_id}.json")
+    do: REST.get(auth, "smart_collections/#{smart_collection_id}.json")
 
   @doc """
   Create a SmartCollection.
@@ -42,7 +42,7 @@ defmodule ShopifyAPI.REST.SmartCollection do
       {:ok, %{ "smart_collection" => %{} }}
   """
   def create(%AuthToken{} = auth, %{smart_collection: %{}} = smart_collection),
-    do: Request.post(auth, "smart_collections.json", smart_collection)
+    do: REST.post(auth, "smart_collections.json", smart_collection)
 
   @doc """
   Update an existing SmartCollection.
@@ -55,7 +55,7 @@ defmodule ShopifyAPI.REST.SmartCollection do
         %AuthToken{} = auth,
         %{smart_collection: %{id: smart_collection_id}} = smart_collection
       ),
-      do: Request.put(auth, "smart_collections/#{smart_collection_id}.json", smart_collection)
+      do: REST.put(auth, "smart_collections/#{smart_collection_id}.json", smart_collection)
 
   @doc """
   Delete a SmartCollection.
@@ -65,5 +65,5 @@ defmodule ShopifyAPI.REST.SmartCollection do
       {:ok, %{ "response": 200 }}
   """
   def delete(%AuthToken{} = auth, smart_collection_id),
-    do: Request.delete(auth, "smart_collections/#{smart_collection_id}.json")
+    do: REST.delete(auth, "smart_collections/#{smart_collection_id}.json")
 end

--- a/lib/shopify_api/rest/tender_transaction.ex
+++ b/lib/shopify_api/rest/tender_transaction.ex
@@ -2,7 +2,7 @@ defmodule ShopifyAPI.REST.TenderTransaction do
   @moduledoc """
   """
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @shopify_per_page_max 250
 
@@ -10,7 +10,7 @@ defmodule ShopifyAPI.REST.TenderTransaction do
     Return all the Tender Transactions.
   """
   def all(%AuthToken{} = auth, params \\ %{}),
-    do: Request.get(auth, "tender_transactions.json?" <> URI.encode_query(params))
+    do: REST.get(auth, "tender_transactions.json?" <> URI.encode_query(params))
 
   def max_per_page, do: @shopify_per_page_max
 end

--- a/lib/shopify_api/rest/theme.ex
+++ b/lib/shopify_api/rest/theme.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.Theme do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a single theme.
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.Theme do
       {:ok, { "theme" => %{} }}
   """
   def get(%AuthToken{} = auth, theme_id, params \\ %{}),
-    do: Request.get(auth, "themes/#{theme_id}.json?" <> URI.encode_query(params))
+    do: REST.get(auth, "themes/#{theme_id}.json?" <> URI.encode_query(params))
 
   @doc """
   Return a list of all themes.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.Theme do
       {:ok, { "themes" => [] }}
   """
   def all(%AuthToken{} = auth, params \\ %{}),
-    do: Request.get(auth, "themes.json?" <> URI.encode_query(params))
+    do: REST.get(auth, "themes.json?" <> URI.encode_query(params))
 
   @doc """
   Update a theme.
@@ -40,7 +40,7 @@ defmodule ShopifyAPI.REST.Theme do
     do: update(auth, %{theme: Map.put(theme, :id, theme_id)})
 
   def update(%AuthToken{} = auth, %{theme: %{id: theme_id}} = theme),
-    do: Request.put(auth, "themes/#{theme_id}.json", theme)
+    do: REST.put(auth, "themes/#{theme_id}.json", theme)
 
   @doc """
   Delete a theme.
@@ -51,7 +51,7 @@ defmodule ShopifyAPI.REST.Theme do
       {:ok, 200 }
   """
   def delete(%AuthToken{} = auth, theme_id),
-    do: Request.delete(auth, "themes/#{theme_id}.json")
+    do: REST.delete(auth, "themes/#{theme_id}.json")
 
   @doc """
   Create a new theme.
@@ -65,5 +65,5 @@ defmodule ShopifyAPI.REST.Theme do
     do: create(auth, %{theme: theme})
 
   def create(%AuthToken{} = auth, %{theme: %{}} = theme),
-    do: Request.post(auth, "themes.json", theme)
+    do: REST.post(auth, "themes.json", theme)
 end

--- a/lib/shopify_api/rest/transaction.ex
+++ b/lib/shopify_api/rest/transaction.ex
@@ -2,14 +2,14 @@ defmodule ShopifyAPI.REST.Transaction do
   @moduledoc """
   """
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
     Return all the Transactions for an Order.
   """
   def all(%AuthToken{} = auth, order_id),
-    do: Request.get(auth, "orders/#{order_id}/transactions.json")
+    do: REST.get(auth, "orders/#{order_id}/transactions.json")
 
   def create(%AuthToken{} = auth, %{transaction: %{order_id: order_id}} = transaction),
-    do: Request.post(auth, "orders/#{order_id}/transactions.json", transaction)
+    do: REST.post(auth, "orders/#{order_id}/transactions.json", transaction)
 end

--- a/lib/shopify_api/rest/usage_charge.ex
+++ b/lib/shopify_api/rest/usage_charge.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.UsageCharge do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Create a usage charge.
@@ -19,7 +19,7 @@ defmodule ShopifyAPI.REST.UsageCharge do
         recurring_application_charge_id,
         usage_charge
       ) do
-    Request.post(
+    REST.post(
       auth,
       "recurring_application_charges/#{recurring_application_charge_id}/usage_charges.json",
       usage_charge
@@ -39,7 +39,7 @@ defmodule ShopifyAPI.REST.UsageCharge do
         recurring_application_charge_id,
         %{usage_charge: %{id: usage_charge_id}}
       ) do
-    Request.get(
+    REST.get(
       auth,
       "recurring_application_charges/#{recurring_application_charge_id}/usage_charges/#{
         usage_charge_id
@@ -56,7 +56,7 @@ defmodule ShopifyAPI.REST.UsageCharge do
       {:ok, { "usage_charges" => [] }}
   """
   def all(%AuthToken{} = auth, recurring_application_charge_id) do
-    Request.get(
+    REST.get(
       auth,
       "recurring_application_charge_id/#{recurring_application_charge_id}/usage_charges.json"
     )

--- a/lib/shopify_api/rest/user.ex
+++ b/lib/shopify_api/rest/user.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.REST.User do
   """
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   Get a single user.
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.User do
       iex> ShopifyAPI.REST.User.get(auth, integer)
       {:ok, { "user" => %{} }}
   """
-  def get(%AuthToken{} = auth, user_id), do: Request.get(auth, "users/#{user_id}.json")
+  def get(%AuthToken{} = auth, user_id), do: REST.get(auth, "users/#{user_id}.json")
 
   @doc """
   Return a list of all users.
@@ -24,7 +24,7 @@ defmodule ShopifyAPI.REST.User do
       iex> ShopifyAPI.REST.User.all(auth)
       {:ok, { "users" => [] }}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "users.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "users.json")
 
   @doc """
   Get the currently logged-in user.
@@ -34,5 +34,5 @@ defmodule ShopifyAPI.REST.User do
       iex> ShopifyAPI.REST.User.current(auth)
       {:ok, { "user" => %{} }}
   """
-  def current(%AuthToken{} = auth), do: Request.get(auth, "users/current.json")
+  def current(%AuthToken{} = auth), do: REST.get(auth, "users/current.json")
 end

--- a/lib/shopify_api/rest/variant.ex
+++ b/lib/shopify_api/rest/variant.ex
@@ -2,12 +2,12 @@ defmodule ShopifyAPI.REST.Variant do
   @moduledoc """
   """
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
     Return a single Product Variant
   """
-  def get(%AuthToken{} = auth, variant_id), do: Request.get(auth, "variants/#{variant_id}.json")
+  def get(%AuthToken{} = auth, variant_id), do: REST.get(auth, "variants/#{variant_id}.json")
 
   @doc """
     Return all of a Product's Variants.
@@ -16,7 +16,7 @@ defmodule ShopifyAPI.REST.Variant do
 
   """
   def all(%AuthToken{} = auth, product_id),
-    do: Request.get(auth, "products/#{product_id}/variants.json")
+    do: REST.get(auth, "products/#{product_id}/variants.json")
 
   @doc """
     Return a count of all Product Variants.
@@ -26,7 +26,7 @@ defmodule ShopifyAPI.REST.Variant do
   """
 
   def count(%AuthToken{} = auth, product_id),
-    do: Request.get(auth, "products/#{product_id}/variants/count.json")
+    do: REST.get(auth, "products/#{product_id}/variants/count.json")
 
   @doc """
     Delete a Product Variant.
@@ -35,7 +35,7 @@ defmodule ShopifyAPI.REST.Variant do
   {:ok, %{}}
   """
   def delete(%AuthToken{} = auth, product_id, variant_id),
-    do: Request.delete(auth, "products/#{product_id}/variants/#{variant_id}.json")
+    do: REST.delete(auth, "products/#{product_id}/variants/#{variant_id}.json")
 
   @doc """
     Create a new Product Variant.
@@ -43,11 +43,11 @@ defmodule ShopifyAPI.REST.Variant do
   iex> ShopifyAPI.REST.Variant.create(auth, product_id, %{variant: %{body_html: "Testing variant create", title: "Testing Create Product Variant"}})
   """
   def create(%AuthToken{} = auth, product_id, %{variant: %{}} = variant),
-    do: Request.post(auth, "products/#{product_id}/variants.json", variant)
+    do: REST.post(auth, "products/#{product_id}/variants.json", variant)
 
   @doc """
     Update a Product Variant.
   """
   def update(%AuthToken{} = auth, %{variant: %{id: variant_id}} = variant),
-    do: Request.put(auth, "variants/#{variant_id}.json", variant)
+    do: REST.put(auth, "variants/#{variant_id}.json", variant)
 end

--- a/lib/shopify_api/rest/webhook.ex
+++ b/lib/shopify_api/rest/webhook.ex
@@ -2,7 +2,7 @@ defmodule ShopifyAPI.REST.Webhook do
   @moduledoc """
   """
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.REST.Request
+  alias ShopifyAPI.REST
 
   @doc """
   ## Helper method to generate the callback URI this server responds to.
@@ -23,12 +23,12 @@ defmodule ShopifyAPI.REST.Webhook do
   iex> ShopifyAPI.REST.Webhook.all(auth)
   {:ok, %{"webhooks" => [%{"webhook_id" => "_", "address" => "https://example.com"}]}}
   """
-  def all(%AuthToken{} = auth), do: Request.get(auth, "webhooks.json")
+  def all(%AuthToken{} = auth), do: REST.get(auth, "webhooks.json")
 
-  def get(%AuthToken{} = auth, webhook_id), do: Request.get(auth, "webhooks/#{webhook_id}.json")
+  def get(%AuthToken{} = auth, webhook_id), do: REST.get(auth, "webhooks/#{webhook_id}.json")
 
   def update(%AuthToken{} = auth, %{webhook: %{webhook_id: webhook_id}} = webhook),
-    do: Request.put(auth, "webhooks/#{webhook_id}.json", webhook)
+    do: REST.put(auth, "webhooks/#{webhook_id}.json", webhook)
 
   @doc """
   ## Example
@@ -37,7 +37,7 @@ defmodule ShopifyAPI.REST.Webhook do
   {:ok, %{}}
   """
   def delete(%AuthToken{} = auth, webhook_id),
-    do: Request.delete(auth, "webhooks/#{webhook_id}.json")
+    do: REST.delete(auth, "webhooks/#{webhook_id}.json")
 
   @doc """
   ## Example
@@ -46,5 +46,5 @@ defmodule ShopifyAPI.REST.Webhook do
   {:ok, %{"webhook" => %{"webhook_id" => "_", "address" => "https://example.com"}}}
   """
   def create(%AuthToken{} = auth, %{webhook: %{}} = webhook),
-    do: Request.post(auth, "webhooks.json", webhook)
+    do: REST.post(auth, "webhooks.json", webhook)
 end

--- a/lib/shopify_api/throttled.ex
+++ b/lib/shopify_api/throttled.ex
@@ -1,4 +1,21 @@
 defmodule ShopifyAPI.Throttled do
+  @moduledoc """
+  A wrapper for requests against Shopify's API, implementing request throttling.
+
+  For more information on Shopify's REST API Rate Limiting:
+  https://help.shopify.com/en/api/reference/rest-admin-api-rate-limits
+
+  Request "buckets" are identified based on the provided `AuthToken`. An ets
+  table is checked before making a request, seeing if additional requests are
+  allowed. If not, the client will sleep before attempting the request.
+
+  Upon receiving a HTTP response, the number of allowed requests is
+  extracted from response headers and inserted into the ets table.
+
+  If Shopify returns the `429 Too Many Requests` status code for a request, it
+  will be retried after a delay and re-check of the ets table, to a maximum of
+  10 total attempts (this is configurable).
+  """
   require Logger
 
   alias ShopifyAPI.ThrottleServer

--- a/test/shopify_api/rest_test.exs
+++ b/test/shopify_api/rest_test.exs
@@ -1,9 +1,10 @@
-defmodule ShopifyAPI.REST.RequestTest do
+defmodule ShopifyAPI.RESTTest do
   use ExUnit.Case
 
   import Bypass, only: [expect_once: 4]
 
   alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.REST
   alias ShopifyAPI.REST.Request
 
   defmodule MockAPIResponses do
@@ -41,7 +42,7 @@ defmodule ShopifyAPI.REST.RequestTest do
       &MockAPIResponses.assert_auth_header_set/1
     )
 
-    assert {:ok, _} = Request.get(token, "example")
+    assert {:ok, _} = REST.get(token, "example")
   end
 
   describe "GET" do
@@ -53,7 +54,7 @@ defmodule ShopifyAPI.REST.RequestTest do
         MockAPIResponses.success()
       )
 
-      assert {:ok, _} = Request.get(token, "example")
+      assert {:ok, _} = REST.get(token, "example")
     end
 
     test "returns errors from API on non-200 responses", %{bypass: bypass, token: token} do
@@ -64,7 +65,7 @@ defmodule ShopifyAPI.REST.RequestTest do
         MockAPIResponses.failure()
       )
 
-      assert {:error, %{status_code: 500}} = Request.get(token, "example")
+      assert {:error, %{status_code: 500}} = REST.get(token, "example")
     end
   end
 
@@ -77,7 +78,7 @@ defmodule ShopifyAPI.REST.RequestTest do
         MockAPIResponses.success(201)
       )
 
-      assert {:ok, _} = Request.post(token, "example", %{})
+      assert {:ok, _} = REST.post(token, "example", %{})
     end
 
     test "returns errors from API on non-200 responses", %{bypass: bypass, token: token} do
@@ -88,7 +89,7 @@ defmodule ShopifyAPI.REST.RequestTest do
         MockAPIResponses.failure(422)
       )
 
-      assert {:error, %{status_code: 422}} = Request.post(token, "example", %{})
+      assert {:error, %{status_code: 422}} = REST.post(token, "example", "")
     end
   end
 
@@ -101,7 +102,7 @@ defmodule ShopifyAPI.REST.RequestTest do
         MockAPIResponses.success(200)
       )
 
-      assert {:ok, _} = Request.delete(token, "example")
+      assert {:ok, _} = REST.delete(token, "example")
     end
 
     test "returns errors from API on non-200 responses", %{bypass: bypass, token: token} do
@@ -112,7 +113,7 @@ defmodule ShopifyAPI.REST.RequestTest do
         MockAPIResponses.failure(404)
       )
 
-      assert {:error, %{status_code: 404}} = Request.delete(token, "example")
+      assert {:error, %{status_code: 404}} = REST.delete(token, "example")
     end
   end
 end


### PR DESCRIPTION
This is an attempt to refactor some complexity out of the `ShopifyAPI.REST.Request` module, which had grown a bit cluttered with additional responsibilities and a subtle conflict between implementations: we were defining `get`/`post`/`put`/`delete` wrapper functions that were conflicting with callbacks [defined by HTTPoison.Base](https://github.com/edgurgel/httpoison/blob/master/lib/httpoison/base.ex#L89-L92). In particular, this was [confusing for dialyzer](https://github.com/pixelunion/elixir-shopifyapi/commit/19662f361a88877829326260adf43271bcf74a1f).

To attempt to un-tangle some of this, the following changes are made in this PR:

- responsibility for updating the `ThrottleServer` has been moved from `REST.Request` to the `Throttled` module.
- methods for performing authenticated HTTP actions against the ShopifyAPI have been extracted from `REST.Request` to a new `REST` module.
- handling of API request logging/options has been moved to HTTPoison.Base callbacks

The diff is less scary than it looks, the volume is caused by updating existing `REST.Request` callsites to use `REST`.

This is also partially preparation work for an additional PR to integrate the `:telemetry` project with the `REST.Request` module, replacing the existing logging implementation. This will allow consumers to implement their own, customized request logging if needed, along with additional introspection into their API usage.