### PR TITLE
AuthTokenServer.get returns either {:ok, AuthToken.t()} or {:error, any()} 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- `AuthTokenServer.get` spec has been changed. It will return `{:error, any()}` if it can't find an AuthToken.
+
 ## 0.4.3
 
 - Refactor `ShopifyAPI.REST.Request`, extract underlying `get`/`post`/`put`/`delete` to `ShopifyAPI.REST`.
@@ -25,7 +27,7 @@
 - Support API versioning
 - Coerce events from the queue into %Events{}
 - Change Events in EventQueue to use string destinations and actions
-- Changed Event.t() typespec to be strings for destination and action. 
+- Changed Event.t() typespec to be strings for destination and action.
 
 ## 0.2.7
 


### PR DESCRIPTION
Currently, our `AuthTokenServer.get` implementation returns a tuple, `{:ok, AuthToken.t()}`  or an atom, `:error`. This is the default behaviour of `Map.fetch()` but, it's not a common pattern for APIs. Especially OTP application APIs. 

This PR proposes an update to the `AuthTokenServer.get` implementation so that it always returns a tuple. If successful, the spec remains the same. In the case of an error, a `{:error, any()}` tuple is returned. This will make using `AuthTokenServer.get` more intuitive and we can provide helpful information when a request fails.

This would require a major version bump since this is a breaking change to the `get` spec. 