### PR TITLE
Feature/configurable json encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - `AuthTokenServer.get` spec has been changed. It will return `{:error, any()}` if it can't find an AuthToken.
+- Configurable json serialization.
 
 ## 0.4.3
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,9 @@ config :shopify_api, ShopifyAPI.Webhook, %{
   uri: "https://example.com/shop/webhook"
 }
 
-config :shopify_api, http_timeout: 5000
+config :shopify_api,
+  http_timeout: 5000,
+  json_library: Poison
 
 config :exq,
   json_library: Jason,

--- a/lib/shopify_api/app.ex
+++ b/lib/shopify_api/app.ex
@@ -12,7 +12,7 @@ defmodule ShopifyAPI.App do
             scope: ""
 
   @typedoc """
-      Type that represents a Shopify App
+    Type that represents a Shopify App
   """
   @type t :: %__MODULE__{
           name: String.t(),
@@ -25,6 +25,7 @@ defmodule ShopifyAPI.App do
 
   require Logger
   alias ShopifyAPI.AuthRequest
+  alias ShopifyAPI.JSONSerializer
 
   @doc """
     Generates the install URL for an App and a Shop.
@@ -52,7 +53,7 @@ defmodule ShopifyAPI.App do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         Logger.info(fn -> "#{__MODULE__} [#{domain}] fetched token" end)
         # TODO probably don't use the ! ver of decode
-        {:ok, body |> Poison.decode!() |> Map.get("access_token")}
+        {:ok, body |> JSONSerializer.decode!() |> Map.get("access_token")}
 
       {:ok, %HTTPoison.Response{} = response} ->
         Logger.warn(fn -> "#{__MODULE__} fetching token code: #{response.status_code}" end)
@@ -71,6 +72,8 @@ defmodule ShopifyAPI.AuthRequest do
     Shop domain, and the auth code from the App install.
   """
   require Logger
+
+  alias ShopifyAPI.JSONSerializer
   @headers [{"Content-Type", "application/json"}]
 
   @transport "https://"
@@ -91,6 +94,7 @@ defmodule ShopifyAPI.AuthRequest do
     }
 
     Logger.debug(fn -> "#{__MODULE__} requesting token from #{access_token_url(domain)}" end)
-    HTTPoison.post(access_token_url(domain), Poison.encode!(http_body), @headers)
+    encoded_body = JSONSerializer.encode!(http_body)
+    HTTPoison.post(access_token_url(domain), encoded_body, @headers)
   end
 end

--- a/lib/shopify_api/json_serializer.ex
+++ b/lib/shopify_api/json_serializer.ex
@@ -1,0 +1,17 @@
+defmodule ShopifyAPI.JSONSerializer do
+  @moduledoc """
+  JSONSerializer provides a wrapper for JSON serialization which is configurable via the :shopify_api application configuration. It defaults to Poison for legacy support.
+
+
+  Add the following to your configuration to override:
+  ```
+  config :shopify_api, json_library: Jason
+  ```
+  """
+
+  def decode(json), do: json_library().decode(json)
+  def encode(e), do: json_library().encode(e)
+  def decode!(json), do: json_library().decode!(json)
+  def encode!(e), do: json_library().encode!(e)
+  defp json_library, do: Application.fetch_env!(:shopify_api, :json_library)
+end

--- a/lib/shopify_api/plugs/webhook.ex
+++ b/lib/shopify_api/plugs/webhook.ex
@@ -8,7 +8,7 @@ defmodule ShopifyAPI.Plugs.Webhook do
   require Logger
 
   alias Plug.Conn
-  alias ShopifyAPI.{ConnHelpers, Security}
+  alias ShopifyAPI.{ConnHelpers, JSONSerializer, Security}
   alias ShopifyAPI.EventPipe.Event
 
   def init(opts), do: opts
@@ -46,7 +46,7 @@ defmodule ShopifyAPI.Plugs.Webhook do
          {:ok, content, conn} <- read_body(conn),
          signature <- ConnHelpers.hmac_from_header(conn),
          ^signature <- Security.base64_sha256_hmac(content, secret),
-         {:ok, params} <- Poison.decode(content) do
+         {:ok, params} <- JSONSerializer.decode(content) do
       {:ok, Map.put(conn, :body_params, params)}
     else
       _ -> {:error, conn}

--- a/lib/shopify_api/rest.ex
+++ b/lib/shopify_api/rest.ex
@@ -8,6 +8,7 @@ defmodule ShopifyAPI.REST do
   """
 
   alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.JSONSerializer
   alias ShopifyAPI.REST.Request
 
   @doc false
@@ -17,13 +18,13 @@ defmodule ShopifyAPI.REST do
 
   @doc false
   def post(%AuthToken{} = auth, path, object \\ %{}) do
-    with {:ok, body} <- Poison.encode(object),
+    with {:ok, body} <- JSONSerializer.encode(object),
          do: Request.perform(auth, :post, path, body)
   end
 
   @doc false
   def put(%AuthToken{} = auth, path, object) do
-    with {:ok, body} <- Poison.encode(object),
+    with {:ok, body} <- JSONSerializer.encode(object),
          do: Request.perform(auth, :put, path, body)
   end
 

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -10,7 +10,7 @@ defmodule ShopifyAPI.REST.Request do
   require Logger
 
   alias HTTPoison.Error
-  alias ShopifyAPI.{AuthToken, CallLimit, Throttled}
+  alias ShopifyAPI.{AuthToken, CallLimit, JSONSerializer, Throttled}
 
   @default_api_version "2019-04"
 
@@ -71,7 +71,7 @@ defmodule ShopifyAPI.REST.Request do
 
   @impl true
   def process_response_body(body) do
-    Poison.decode(body)
+    JSONSerializer.decode(body)
   end
 
   ## Private Helpers

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule Plug.ShopifyAPI.MixProject do
       {:httpoison, "~> 1.0"},
       {:jason, "~> 1.0"},
       {:plug, "~> 1.0"},
-      {:poison, "~> 3.1"},
+      {:poison, "~> 3.1", optional: true},
       {:telemetry, "~> 0.4.0"}
     ]
   end

--- a/test/shopify_api/plugs/webhook_test.exs
+++ b/test/shopify_api/plugs/webhook_test.exs
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.Plugs.WebhookTest do
 
   alias Plug.Conn
   alias ShopifyAPI.Plugs.Webhook
-  alias ShopifyAPI.{App, AppServer, Shop, ShopServer}
+  alias ShopifyAPI.{App, AppServer, JSONSerializer, Shop, ShopServer}
 
   @app %App{name: "test"}
   @shop %Shop{domain: "test-shop.example.com"}
@@ -24,7 +24,7 @@ defmodule ShopifyAPI.Plugs.WebhookTest do
     # Create a test connection
     conn =
       :post
-      |> conn("/webhook/#{@app.name}", Poison.encode!(@req_body))
+      |> conn("/webhook/#{@app.name}", JSONSerializer.encode!(@req_body))
       |> Conn.put_req_header("x-shopify-hmac-sha256", "invalid")
       |> Conn.put_req_header("x-shopify-shop-domain", @shop.domain)
 
@@ -41,7 +41,7 @@ defmodule ShopifyAPI.Plugs.WebhookTest do
     # Create a test connection
     conn =
       :post
-      |> conn("/webhook/#{@app.name}?", Poison.encode!(@req_body))
+      |> conn("/webhook/#{@app.name}?", JSONSerializer.encode!(@req_body))
       |> Conn.fetch_query_params()
       |> Conn.put_req_header(
         "x-shopify-hmac-sha256",

--- a/test/shopify_api/rest/product_test.exs
+++ b/test/shopify_api/rest/product_test.exs
@@ -2,9 +2,7 @@ defmodule ShopifyAPI.REST.ProductTest do
   use ExUnit.Case
 
   alias Plug.Conn
-
-  alias ShopifyAPI.{AuthToken, Shop}
-
+  alias ShopifyAPI.{AuthToken, JSONSerializer, Shop}
   alias ShopifyAPI.REST.{Product, Request}
 
   setup _context do
@@ -28,7 +26,7 @@ defmodule ShopifyAPI.REST.ProductTest do
     }
 
     Bypass.expect_once(bypass, "GET", "/admin/api/#{Request.version()}/products.json", fn conn ->
-      {:ok, body} = Poison.encode(products)
+      {:ok, body} = JSONSerializer.encode(products)
       Conn.resp(conn, 200, body)
     end)
 

--- a/test/shopify_api/router_test.exs
+++ b/test/shopify_api/router_test.exs
@@ -2,9 +2,8 @@ defmodule Test.ShopifyAPI.RouterTest do
   use ExUnit.Case
   use Plug.Test
 
+  alias ShopifyAPI.{AppServer, AuthTokenServer, JSONSerializer, Router, Security, ShopServer}
   alias Plug.{Conn, Parsers}
-
-  alias ShopifyAPI.{AppServer, AuthTokenServer, Router, Security, ShopServer}
 
   @moduletag :capture_log
 
@@ -82,7 +81,7 @@ defmodule Test.ShopifyAPI.RouterTest do
 
     test "fetches the token", %{bypass: bypass, shop_domain: shop_domain} do
       Bypass.expect_once(bypass, "POST", "/admin/oauth/access_token", fn conn ->
-        {:ok, body} = Poison.encode(@token)
+        {:ok, body} = JSONSerializer.encode(@token)
         Conn.resp(conn, 200, body)
       end)
 


### PR DESCRIPTION
Make our json serialization configurable, with the intent of moving towards Jason.

Add a new configuration setting for specifying what json serialization library to use.
`config :shopify_api, json_library: Jason`