### PR TITLE
Customer Authentication Plug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add Customer Authentication Plug [ch51782]
+
 ## 0.5.0
 
 - `AuthTokenServer.get` spec has been changed. It will return `{:error, any()}` if it can't find an AuthToken.

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,3 +5,5 @@ config :exq, start_on_application: false
 # Print only warnings and errors during test
 config :logger, level: :warn
 config :bypass, adapter: Plug.Adapters.Cowboy2
+
+config :shopify_api, :customer_api_secret_keys, ["new_secret", "old_secret"]

--- a/lib/shopify_api/plugs/customer_authenticator.ex
+++ b/lib/shopify_api/plugs/customer_authenticator.ex
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.Plugs.CustomerAuthenticator do
 
   ## Liquid Template
 
-  You can create the payload for and signature for that this plug will consume with the following `liquid` template:
+  You can create the payload and signature that this plug will consume with the following `liquid` template:
   ```liquid
     {% assign auth_expiry = "now" | date: "%s" | plus: 3600 | date: "%Y-%m-%dT%H:%M:%S.%L%z" %}
     {% capture json_string %}
@@ -17,11 +17,11 @@ defmodule ShopifyAPI.Plugs.CustomerAuthenticator do
   The payload itself can be modified to include additional fields so long as it is valid json and contains the `expiry`.
   The original intent was for this to generate a JWT, but Liquid does not include base64 encoding.
 
-  The combination of the payload and signature should be considered an access token. If it is compromised, an attacker will have be able to make requests with the token until the token expires.
+  The combination of the payload and signature should be considered an access token. If it is compromised, an attacker will be able to make requests with the token until the token expires.
 
   ### Including Auth in calls
 
-  Include the payload and signatures in rest calls by including it in the payload.
+  Include the payload and signatures in API calls by including it in the payload.
 
   ```liquid
   data: {
@@ -60,8 +60,12 @@ defmodule ShopifyAPI.Plugs.CustomerAuthenticator do
   ## Example Usage
 
   ```elixir
-  scope "/api", YourAppWeb do
+  pipeline :customer_auth do
     plug ShopifyAPI.Plugs.CustomerAuthenticator
+  end
+
+  scope "/api", YourAppWeb do
+    pipe_through(:customer_auth)
 
     get "/", CustomerAPIController, :index
   end

--- a/lib/shopify_api/plugs/customer_authenticator.ex
+++ b/lib/shopify_api/plugs/customer_authenticator.ex
@@ -1,0 +1,94 @@
+defmodule ShopifyAPI.Plugs.CustomerAuthenticator do
+  @moduledoc """
+  The Shopify.Plugs.CustomerAuthenticator plug allows for authentication of a customer call being made from a Shopify shop with a signed payload.
+
+  ## Liquid Template
+
+  You can create the payload for and signature for that this plug will consume with the following `liquid` template:
+  ```liquid
+    {% assign auth_expiry = "now" | date: "%s" | plus: 86400 | date: "%Y-%m-%dT%H:%M:%S.%L%z" %}
+    {% capture json_string %}
+      {"email":"{{ customer.email }}","id":"{{ customer.id }}","expiry":"{{ auth_expiry }}"}
+    {% endcapture %}
+    {% assign AUTH_PAYLOAD = json_string | strip %}
+    {% assign AUTH_SIGNATURE = AUTH_PAYLOAD | hmac_sha256: settings.secret %}
+  ```
+  The payload itself can be modified to include additional fields so long as it is valid json.
+  The original intent was for this to generate a JWT, but Liquid does not include base64 encoding.
+
+
+  ## Configuring Secrets
+
+  Include a shared secret in your Elixir config and in your Shopify settings. You can provide a list to make rotating secrets easier.
+
+  ```elixir
+  # config.exs
+  config :shopify_api, :customer_api_secret_keys, ["new_secret", "old_secret"]
+  ```
+
+  ## Example Usage
+
+  ```elixir
+  pipeline :customer_api do
+    plug ShopifyAPI.Plugs.CustomerAuthenticator
+  end
+
+  scope "/api", YourAppWeb do
+    pipe_through :browser
+    pipe_through :customer_api
+    get "/", CustomerAPIController, :index
+  end
+  ```
+  """
+
+  import Plug.Conn
+
+  alias ShopifyAPI.Security
+  alias ShopifyAPI.JSONSerializer
+
+  def init(_opts) do
+    %{customer_api_secret_keys: Application.get_env(:shopify_api, :customer_api_secret_keys)}
+  end
+
+  def call(
+        %{params: %{"auth_payload" => payload, "auth_signature" => signature}} = conn,
+        opts
+      ) do
+    with :ok <- validate_signature(payload, signature, customer_api_secret_keys()),
+         {:ok, auth_context} <- parse_payload(payload) do
+      conn
+      |> assign(:auth_context, auth_context)
+    else
+      :error ->
+        send_unauthorized_response(conn, "Authorization failed")
+
+      {:error, _} ->
+        send_unauthorized_response(conn, "Could not parse auth_payload")
+    end
+  end
+
+  def call(conn, _), do: send_unauthorized_response(conn, "Authorization failed")
+
+  def valid_signature?(auth_payload, signature, secrets) when is_list(secrets) do
+    Enum.any?(secrets, fn secret ->
+      signature == Security.base16_sha256_hmac(auth_payload, secret)
+    end)
+  end
+
+  def validate_signature(auth_payload, signature, secret),
+    do: validate_signature(auth_payload, signature, [secret])
+
+  defp parse_payload(payload) do
+    JSONSerializer.decode(payload)
+  end
+
+  defp customer_api_secret_keys do
+    Application.get_env(:shopify_api, :customer_api_secret_keys, [])
+  end
+
+  defp send_unauthorized_response(conn, message) do
+    conn
+    |> resp(401, message)
+    |> halt()
+  end
+end

--- a/lib/shopify_api/plugs/customer_authenticator.ex
+++ b/lib/shopify_api/plugs/customer_authenticator.ex
@@ -73,9 +73,7 @@ defmodule ShopifyAPI.Plugs.CustomerAuthenticator do
   alias ShopifyAPI.JSONSerializer
   alias ShopifyAPI.Security
 
-  def init(_opts) do
-    %{customer_api_secret_keys: Application.get_env(:shopify_api, :customer_api_secret_keys)}
-  end
+  def init(opts), do: opts
 
   def call(
         %{params: %{"auth_payload" => payload, "auth_signature" => signature}} = conn,

--- a/lib/shopify_api/plugs/customer_authenticator.ex
+++ b/lib/shopify_api/plugs/customer_authenticator.ex
@@ -17,11 +17,18 @@ defmodule ShopifyAPI.Plugs.CustomerAuthenticator do
   The payload itself can be modified to include additional fields so long as it is valid json and contains the `expiry`.
   The original intent was for this to generate a JWT, but Liquid does not include base64 encoding.
 
-  Include the payload and signatures in rest calls:
+  ### Including Auth in calls
 
+  Include the payload and signatures in rest calls by including it in the payload.
 
+  ```liquid
+  data: {
+    auth_payload: {{ AUTH_PAYLOAD | json }},
+    auth_signature: {{ AUTH_SIGNATURE | json }}
+  }
+  ```
 
-  Include the payload and signatures in a form:
+  You can also include the payload and signatures in a form.
 
   ```liquid
   <input

--- a/test/shopify_api/plugs/customer_authenticator_test.exs
+++ b/test/shopify_api/plugs/customer_authenticator_test.exs
@@ -1,0 +1,170 @@
+defmodule ShopifyAPI.Plugs.CustomerAuthenticatorTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias ShopifyAPI.Plugs.CustomerAuthenticator
+  alias ShopifyAPI.Security
+
+  @secret "new_secret"
+
+  describe "Valid Customer Auth" do
+    test "assigns auth_payload to conn" do
+      payload = auth_payload()
+      signature = Security.base16_sha256_hmac(payload, @secret)
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert %{
+               "email" => "email@example.com",
+               "expiry" => _,
+               "id" => "12345"
+             } = conn.assigns.auth_payload
+    end
+
+    test "validates on second secret as well" do
+      payload = auth_payload()
+      signature = Security.base16_sha256_hmac(payload, "old_secret")
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert %{
+               "email" => "email@example.com",
+               "expiry" => _,
+               "id" => "12345"
+             } = conn.assigns.auth_payload
+    end
+  end
+
+  describe "Invalid Customer Auth" do
+    test "payload expired" do
+      payload = DateTime.utc_now() |> add_seconds(-3600) |> auth_payload()
+      signature = Security.base16_sha256_hmac(payload, "new_secret")
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "auth_payload has expired")
+    end
+
+    test "malformed payload" do
+      payload = "this payload is invalid"
+      signature = Security.base16_sha256_hmac(payload, "new_secret")
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "Could not parse auth_payload")
+    end
+
+    test "wrong secret" do
+      payload = auth_payload()
+      signature = Security.base16_sha256_hmac(payload, "wrong_secret")
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "Authorization failed")
+    end
+
+    test "no payload" do
+      payload = auth_payload()
+      signature = Security.base16_sha256_hmac(payload, "new_secret")
+
+      conn =
+        :post
+        |> conn("/", %{auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "Authorization failed")
+    end
+
+    test "no signature" do
+      payload = auth_payload()
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "Authorization failed")
+    end
+
+    test "empty payload" do
+      payload = ""
+      signature = Security.base16_sha256_hmac(payload, "new_secret")
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "Could not parse auth_payload")
+    end
+
+    test "empty expiry" do
+      payload = ~s({"email":"email@example.com","id":"12345","expiry":""})
+      signature = Security.base16_sha256_hmac(payload, "new_secret")
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "A valid ISO8601 expiry must be included in auth_payload")
+    end
+
+    test "malformed expiry" do
+      payload = ~s({"email":"email@example.com","id":"12345","expiry":"baddate"})
+      signature = Security.base16_sha256_hmac(payload, "new_secret")
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "A valid ISO8601 expiry must be included in auth_payload")
+    end
+
+    test "empty signature" do
+      payload = auth_payload()
+      signature = Security.base16_sha256_hmac(payload, "")
+
+      conn =
+        :post
+        |> conn("/", %{auth_payload: payload, auth_signature: signature})
+        |> CustomerAuthenticator.call([])
+
+      assert_unauthorized(conn, "Authorization failed")
+    end
+  end
+
+  defp assert_unauthorized(conn, message) do
+    assert conn.status == 401
+    assert conn.resp_body == message
+    assert conn.assigns == %{}
+  end
+
+  defp auth_payload, do: DateTime.utc_now() |> add_seconds(360) |> auth_payload()
+
+  defp auth_payload(expiry),
+    do: ~s({"email":"email@example.com","id":"12345","expiry":"#{DateTime.to_iso8601(expiry)}"})
+
+  defp add_seconds(date_time, seconds) do
+    date_time
+    |> DateTime.to_naive()
+    |> NaiveDateTime.add(seconds)
+    |> DateTime.from_naive!("Etc/UTC")
+  end
+end


### PR DESCRIPTION
Adds a plug that can be used for customer authentication. This plug is useful for authenticating calls made from the Shopify front end to an elixir backend. 

The intent was to generate a JWT to get an expiry and a payload as part of the authentication. When that proved to be not feasible in liquid, I came up with something simple that got us most of the way there.

