### PR TITLE
add internal interface to Shopify's GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Add internal GraphQL interface to Shopify's GraphQL API
 
 ## 0.5.1
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     - [Apps](#Apps)
     - [AuthTokens](#AuthTokens)
   - [Webhooks](#Webhooks)
+  - [GraphQL](#GraphQL)
   - [Telemetry](#Telemetry)
 
 ## Installation
@@ -209,6 +210,33 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/shopify_api](https://hexdocs.pm/shopify_api).
 
+## GraphQL
+
+`GraphQL` implementation handles GraphQL Queries against Shopify API using HTTPoison library as client, this initial implementation consists of hitting Shopify GraphQL and returning the response in a tuple `{:ok, %Response{}} | {:error, %Response{}}` containing the response and metadata(actualQueryCost, throttleStatus).
+
+Configure the version to use in your config.exs, it will default to a stable version as ref'd in the [graphql module](lib/shopify_api/graphql.ex).
+
+
+```elixir
+config :shopify_api, ShopifyAPI.GraphQL, graphql_version: "2019-07"
+```
+
+### GraphQL Response
+
+Because `GraphQL responses` can be a little complex we are parsing/wraping responses `%HTTPoison.response` to `%GraphQL.Response`.
+
+Successful response:
+
+```elixir
+{:ok, %ShopifyAPI.GraphQL.Response{response: %{}, metadata: %{}, status_code: code}}
+```
+
+Failed response:
+
+```elixir
+{:error, %HTTPoison.Response{}}
+```
+
 ## Telemetry
 
 The `shopify_api` library will emit events using the [`:telemetry`](https://github.com/beam-telemetry/telemetry) library. Consumers of `shopify_api` can then use these events for customized metrics aggregation and more.
@@ -217,6 +245,8 @@ The following telemetry events are generated:
 - `[:shopify_api, :rest_request, :failure]`
 - `[:shopify_api, :throttling, :over_limit]`
 - `[:shopify_api, :throttling, :within_limit]`
+- `[:shopify_api, :graphql_request, :success]`
+- `[:shopify_api, :graphql_request, :failure]`
   
 As an example, you could use an external module to instrument API requests made by `shopify_api`:
 

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -1,0 +1,146 @@
+defmodule ShopifyAPI.GraphQL do
+  @moduledoc """
+  Interface to Shopify's GraphQL Admin API. 
+  """
+
+  require Logger
+
+  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.GraphQL.{Response, Telemetry}
+  alias ShopifyAPI.JSONSerializer
+
+  # Use HTTP in test for Bypass, HTTPS in all other environments
+  @transport if Mix.env() == :test, do: "http://", else: "https://"
+
+  @default_graphql_version "2019-07"
+
+  @log_module __MODULE__ |> to_string() |> String.trim_leading("Elixir.")
+
+  @doc ~S[
+    Makes requests against Shopify GraphQL and returns a tuple containig
+    a %Response struct with %{response, metadata, status_code}
+    
+    ## Example
+    
+      iex> query =  %{
+        operationName: "metafieldDelete", 
+        query: "mutation metafieldDelete($input: MetafieldDeleteInput!){metafieldDelete(input: $input) {deletedId userErrors {field message }}}", 
+        variables: %{input: %{id: "gid://shopify/Metafield/9208558682200"}}
+      }
+      """
+    
+      iex> ShopifyAPI.GraphQL.query(auth, query)
+      {:ok, %Response{...}}
+    ]
+  def query(%AuthToken{} = auth, query_string, variables \\ %{}, opts \\ []) do
+    url = build_url(auth, opts)
+    headers = build_headers(auth, opts)
+
+    body =
+      query_string
+      |> build_body()
+      |> insert_variables(variables)
+      |> JSONSerializer.encode!()
+
+    logged_request(auth, url, body, headers, opts)
+  end
+
+  defp build_body(query_string), do: %{query: query_string}
+
+  defp insert_variables(body, variables) do
+    Map.put(body, :variables, variables)
+  end
+
+  def configured_version do
+    config = Application.get_env(:shopify_api, ShopifyAPI.GraphQL, [])
+    Keyword.get(config, :graphql_version, @default_graphql_version)
+  end
+
+  @doc """
+  Returns rate limit info back from succesful responses.
+  """
+  def rate_limit_details({:ok, %Response{metadata: metadata}}) do
+    actual_cost =
+      metadata
+      |> get_in(["cost", "actualQueryCost"])
+      |> Kernel.trunc()
+
+    currently_available =
+      metadata
+      |> get_in(["cost", "throttleStatus", "currentlyAvailable"])
+      |> Kernel.trunc()
+
+    maximum_available =
+      metadata
+      |> get_in(["cost", "throttleStatus", "maximumAvailable"])
+      |> Kernel.trunc()
+
+    rate_limit(actual_cost, currently_available, maximum_available)
+  end
+
+  def rate_limit_details(_) do
+    rate_limit(nil, nil, nil)
+  end
+
+  defp rate_limit(actual_cost, currently_available, maximum_available) do
+    %{
+      actual_cost: actual_cost,
+      currently_available: currently_available,
+      maximum_available: maximum_available
+    }
+  end
+
+  defp logged_request(auth, url, body, headers, options) do
+    {time, response} = :timer.tc(HTTPoison, :post, [url, body, headers, options])
+
+    response = Response.handle(response)
+
+    log_request(auth, response, time)
+
+    Telemetry.send(@log_module, auth, url, time, response)
+
+    response
+  end
+
+  defp log_request(%{app_name: app, shop_name: shop} = _token, response, time) do
+    Logger.debug(fn ->
+      status =
+        case response do
+          {:ok, %{status_code: status}} -> status
+          {:error, reason} -> "error[#{inspect(reason)}]"
+        end
+
+      case rate_limit_details(response) do
+        %{actual_cost: nil, currently_available: nil, maximum_available: nil} ->
+          "#{@log_module} for #{shop}:#{app} received #{status} in #{div(time, 1_000)}ms"
+
+        %{
+          actual_cost: actual_cost,
+          currently_available: currently_available,
+          maximum_available: maximum_available
+        } ->
+          "#{@log_module} for #{shop}:#{app} received #{status} in #{div(time, 1_000)}ms [cost #{
+            actual_cost
+          } bucket #{currently_available}/#{maximum_available}]"
+      end
+    end)
+  end
+
+  defp build_url(%{shop_name: domain}, opts) do
+    version = Keyword.get(opts, :version, configured_version())
+    "#{@transport}#{domain}/admin/api/#{version}/graphql.json"
+  end
+
+  defp build_headers(%{token: access_token}, opts) do
+    headers = [
+      {"Content-Type", "application/json"},
+      {"X-Shopify-Access-Token", access_token}
+    ]
+
+    if Keyword.get(opts, :debug, false) do
+      [{"X-GraphQL-Cost-Include-Fields", "true"} | headers]
+    else
+      headers
+    end
+  end
+end

--- a/lib/shopify_api/graphql/parse_error.ex
+++ b/lib/shopify_api/graphql/parse_error.ex
@@ -1,0 +1,15 @@
+defmodule ShopifyAPI.GraphQL.JSONParseError do
+  @moduledoc """
+  Struct representation of a JSON parse error.
+  """
+
+  alias HTTPoison.Response
+
+  @type t :: %ShopifyAPI.GraphQL.JSONParseError{
+          error: map(),
+          response: Response.t()
+        }
+
+  defstruct response: %Response{},
+            error: nil
+end

--- a/lib/shopify_api/graphql/response.ex
+++ b/lib/shopify_api/graphql/response.ex
@@ -1,0 +1,63 @@
+defmodule ShopifyAPI.GraphQL.Response do
+  @moduledoc """
+  The Response module handles parsing and unwrapping responses from Shopify's GraphQL Admin API.
+  """
+
+  alias ShopifyAPI.JSONSerializer
+  alias ShopifyAPI.GraphQL.{JSONParseError, Response}
+
+  @type t :: %ShopifyAPI.GraphQL.Response{
+          response: map(),
+          metadata: map(),
+          status_code: integer(),
+          headers: list()
+        }
+
+  defstruct response: %{},
+            metadata: %{},
+            status_code: nil,
+            headers: []
+
+  @doc """
+  Parses a `%HTTPoison.Response{}` GraphQL response.
+
+  Returns `{:ok, %Response{}}` if the API response was successful.
+  If there were query errors, or a rate limit was exceeded, `{:error, %HTTPoison.Response{}}` is returned.
+  If an error occurs while parsing the JSON response, `{:error, %JSONParseError{}}` is returned.
+  """
+
+  def handle({:ok, response}) do
+    case JSONSerializer.decode(response.body) do
+      {:ok, body} -> build_response(%{response | body: body})
+      {:error, error} -> handle_unparsable(response, error)
+      {:error, error, _} -> handle_unparsable(response, error)
+    end
+  end
+
+  def handle({:error, _} = response, _), do: response
+
+  @doc false
+  def build_response(%{body: %{"data" => data, "extensions" => extensions}} = response) do
+    {
+      :ok,
+      %Response{
+        status_code: response.status_code,
+        response: data,
+        metadata: extensions,
+        headers: response.headers
+      }
+    }
+  end
+
+  def build_response(response), do: {:error, response}
+
+  def handle_unparsable(response, error) do
+    {
+      :error,
+      %JSONParseError{
+        response: response,
+        error: error
+      }
+    }
+  end
+end

--- a/lib/shopify_api/graphql/telemtry.ex
+++ b/lib/shopify_api/graphql/telemtry.ex
@@ -1,0 +1,55 @@
+defmodule ShopifyAPI.GraphQL.Telemetry do
+  @moduledoc """
+  Helper module handle instrumentation with telemetry
+  """
+  alias HTTPoison.Error
+  alias ShopifyAPI.GraphQL.Response
+
+  def send(
+        module_name,
+        %{app_name: app, shop_name: shop} = _token,
+        time,
+        {:ok, %Response{response: response}} = _response
+      ) do
+    metadata = %{
+      app: app,
+      shop: shop,
+      module: module_name,
+      response: response
+    }
+
+    telemetry_execute(:success, time, metadata)
+  end
+
+  def send(
+        module_name,
+        %{app_name: app, shop_name: shop} = _token,
+        time,
+        response
+      ) do
+    reason =
+      case response do
+        {:error, %Response{response: reason}} -> reason
+        {:error, %Error{reason: reason}} -> reason
+      end
+
+    metadata = %{
+      app: app,
+      shop: shop,
+      module: module_name,
+      reason: reason
+    }
+
+    telemetry_execute(:failure, time, metadata)
+  end
+
+  def send(_token, _method, _url, _time, _response), do: nil
+
+  defp telemetry_execute(event_status, time, metadata) do
+    :telemetry.execute(
+      [:shopify_api, :graphql_request, event_status],
+      %{request_time: time},
+      metadata
+    )
+  end
+end

--- a/test/shopify_api/graphql/graphql_test.exs
+++ b/test/shopify_api/graphql/graphql_test.exs
@@ -1,0 +1,207 @@
+defmodule ShopifyAPI.GraphQL.GraphQLTest do
+  use ExUnit.Case
+
+  alias Plug.Conn
+  alias ShopifyAPI.{AuthToken, JSONSerializer, Shop}
+  alias ShopifyAPI.GraphQL
+  alias ShopifyAPI.GraphQL.Response
+
+  @data %{
+    "metafield1" => %{
+      "deletedId" => "gid://shopify/Metafield/5256098316335",
+      "userErrors" => []
+    }
+  }
+
+  @data_does_not_exist %{
+    "metafield1" => %{
+      "deletedId" => nil,
+      "userErrors" => [
+        %{"field" => ["id"], "message" => "Metafield does not exist"}
+      ]
+    }
+  }
+
+  @cost_exceeded [%{"message" => "Query has a cost of 1100, which exceeds the max cost of 1000"}]
+
+  @metadata %{
+    "cost" => %{
+      "actualQueryCost" => 10,
+      "fields" => [
+        %{
+          "definedCost" => 10,
+          "path" => ["metafield1"],
+          "requestedChildrenCost" => 0,
+          "requestedTotalCost" => 10
+        }
+      ],
+      "requestedQueryCost" => 10,
+      "throttleStatus" => %{
+        "currentlyAvailable" => 990,
+        "maximumAvailable" => 1.0e3,
+        "restoreRate" => 50.0
+      }
+    }
+  }
+
+  @row_query_string "mutation {metafield0: metafieldDelete (input: {id: \"gid://shopify/Metafield/9208558682200\"}){deletedId userErrors {field message }}}"
+
+  @query_string "mutation metafieldDelete($input: MetafieldDeleteInput!){metafieldDelete(input: $input) {deletedId userErrors {field message }}}"
+
+  @variables %{input: %{id: "gid://shopify/Metafield/9208558682200"}}
+
+  setup _context do
+    bypass = Bypass.open()
+
+    token = %AuthToken{
+      token: "1234",
+      shop_name: "localhost:#{bypass.port}"
+    }
+
+    shop = %Shop{domain: "localhost:#{bypass.port}"}
+
+    {:ok, %{bypass: bypass, auth_token: token, shop: shop}}
+  end
+
+  describe "GraphQL query/2" do
+    test "when mutation has parametized variables", %{
+      bypass: bypass,
+      shop: _shop,
+      auth_token: token
+    } do
+      response = Map.merge(%{"data" => @data}, %{"extensions" => @metadata})
+
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/admin/api/#{GraphQL.configured_version()}/graphql.json",
+        fn conn ->
+          {:ok, body} = JSONSerializer.encode(response)
+          Conn.resp(conn, 200, body)
+        end
+      )
+
+      assert {:ok, %Response{response: @data, metadata: @metadata, status_code: 200}} =
+               GraphQL.query(token, @query_string, @variables)
+    end
+
+    test "when mutation is a query string", %{
+      bypass: bypass,
+      shop: _shop,
+      auth_token: token
+    } do
+      response = Map.merge(%{"data" => @data}, %{"extensions" => @metadata})
+
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/admin/api/#{GraphQL.configured_version()}/graphql.json",
+        fn conn ->
+          {:ok, body} = JSONSerializer.encode(response)
+          Conn.resp(conn, 200, body)
+        end
+      )
+
+      assert {:ok, %Response{response: @data, metadata: @metadata, status_code: 200}} =
+               GraphQL.query(token, @row_query_string)
+    end
+
+    test "when deleting a metafield that does not exist", %{
+      bypass: bypass,
+      shop: _shop,
+      auth_token: token
+    } do
+      response = Map.merge(%{"data" => @data_does_not_exist}, %{"extensions" => @metadata})
+
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/admin/api/#{GraphQL.configured_version()}/graphql.json",
+        fn conn ->
+          {:ok, body} = JSONSerializer.encode(response)
+          Conn.resp(conn, 200, body)
+        end
+      )
+
+      assert {:ok,
+              %Response{response: @data_does_not_exist, metadata: @metadata, status_code: 200}} =
+               GraphQL.query(token, @query_string, @variables)
+    end
+
+    test "when query exceeds max cost for 1000", %{
+      bypass: bypass,
+      shop: _shop,
+      auth_token: token
+    } do
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/admin/api/#{GraphQL.configured_version()}/graphql.json",
+        fn conn ->
+          {:ok, body} = JSONSerializer.encode(@cost_exceeded)
+          Conn.resp(conn, 200, body)
+        end
+      )
+
+      assert {:error, %HTTPoison.Response{}} = GraphQL.query(token, @query_string, @variables)
+    end
+  end
+
+  describe "Response remaining_points/1" do
+    test "when response contains metadata", %{
+      bypass: bypass,
+      shop: _shop,
+      auth_token: token
+    } do
+      response = Map.merge(%{"data" => @data}, %{"extensions" => @metadata})
+
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/admin/api/#{GraphQL.configured_version()}/graphql.json",
+        fn conn ->
+          {:ok, body} = JSONSerializer.encode(response)
+          Conn.resp(conn, 200, body)
+        end
+      )
+
+      rate_limit_details =
+        token
+        |> GraphQL.query(@query_string, @variables)
+        |> GraphQL.rate_limit_details()
+
+      assert %{
+               actual_cost: 10,
+               currently_available: 990,
+               maximum_available: 1000
+             } == rate_limit_details
+    end
+
+    test "when response does not contain metadata", %{
+      bypass: bypass,
+      shop: _shop,
+      auth_token: token
+    } do
+      Bypass.expect_once(
+        bypass,
+        "POST",
+        "/admin/api/#{GraphQL.configured_version()}/graphql.json",
+        fn conn ->
+          {:ok, body} = JSONSerializer.encode(@cost_exceeded)
+          Conn.resp(conn, 200, body)
+        end
+      )
+
+      rate_limit_details =
+        token
+        |> GraphQL.query(@query_string, @variables)
+        |> GraphQL.rate_limit_details()
+
+      assert %{
+               actual_cost: nil,
+               currently_available: nil,
+               maximum_available: nil
+             } == rate_limit_details
+    end
+  end
+end

--- a/test/shopify_api/graphql/response_test.exs
+++ b/test/shopify_api/graphql/response_test.exs
@@ -1,0 +1,181 @@
+defmodule ShopifyAPI.GraphQL.ResponseTest do
+  use ExUnit.Case
+
+  alias ShopifyAPI.GraphQL.Response
+
+  @httpoison_response {:ok,
+                       %HTTPoison.Response{
+                         body:
+                           "{\"data\":{\"metafield1\":{\"deletedId\":\"gid://shopify/Metafield/5256098316335\",\"userErrors\":[]}},\"extensions\":{\"cost\":{\"actualQueryCost\":10,\"fields\":[{\"definedCost\":10,\"path\":[\"metafield1\"],\"requestedChildrenCost\":0,\"requestedTotalCost\":10}],\"requestedQueryCost\":10,\"throttleStatus\":{\"currentlyAvailable\":990,\"maximumAvailable\":1.0e3,\"restoreRate\":50.0}}}}",
+                         headers: [
+                           {"cache-control", "max-age=0, private, must-revalidate"},
+                           {"content-length", "352"},
+                           {"date", "Tue, 20 Aug 2019 20:27:42 GMT"},
+                           {"server", "Cowboy"}
+                         ],
+                         request: %HTTPoison.Request{
+                           body:
+                             "mutation {\n    metafield1: metafieldDelete (input: {id: \"gid://shopify/Metafield/123456789\"}){\n    deletedId\n    userErrors {\n      field\n      message\n      }\n    }\n  }",
+                           headers: [
+                             {"Content-Type", "application/graphql"},
+                             {"X-Shopify-Access-Token", "1234"}
+                           ],
+                           method: :post,
+                           options: [
+                             token: %ShopifyAPI.AuthToken{
+                               app_name: "",
+                               code: "",
+                               plus: false,
+                               shop_name: "localhost:60370",
+                               timestamp: 0,
+                               token: "1234"
+                             }
+                           ],
+                           params: %{},
+                           url: "http://localhost:60370/admin/api/2019-07/graphql.json"
+                         },
+                         request_url: "http://localhost:60370/admin/api/2019-07/graphql.json",
+                         status_code: 200
+                       }}
+
+  @httpoison_error_response {:ok,
+                             %HTTPoison.Response{
+                               body:
+                                 "[{\"message\":\"Query has a cost of 1100, which exceeds the max cost of 1000\"}]",
+                               headers: [
+                                 {"cache-control", "max-age=0, private, must-revalidate"},
+                                 {"content-length", "76"},
+                                 {"date", "Tue, 20 Aug 2019 20:30:20 GMT"},
+                                 {"server", "Cowboy"}
+                               ],
+                               request: %HTTPoison.Request{
+                                 body:
+                                   "mutation {\n    metafield1: metafieldDelete (input: {id: \"gid://shopify/Metafield/123456789\"}){\n    deletedId\n    userErrors {\n      field\n      message\n      }\n    }\n  }",
+                                 headers: [
+                                   {"Content-Type", "application/graphql"},
+                                   {"X-Shopify-Access-Token", "1234"}
+                                 ],
+                                 method: :post,
+                                 options: [
+                                   token: %ShopifyAPI.AuthToken{
+                                     app_name: "",
+                                     code: "",
+                                     plus: false,
+                                     shop_name: "localhost:60536",
+                                     timestamp: 0,
+                                     token: "1234"
+                                   }
+                                 ],
+                                 params: %{},
+                                 url: "http://localhost:60536/admin/api/2019-07/graphql.json"
+                               },
+                               request_url:
+                                 "http://localhost:60536/admin/api/2019-07/graphql.json",
+                               status_code: 200
+                             }}
+
+  describe "Response handle/1" do
+    test "when response is succesful" do
+      success =
+        {:ok,
+         %ShopifyAPI.GraphQL.Response{
+           metadata: %{
+             "cost" => %{
+               "actualQueryCost" => 10,
+               "fields" => [
+                 %{
+                   "definedCost" => 10,
+                   "path" => ["metafield1"],
+                   "requestedChildrenCost" => 0,
+                   "requestedTotalCost" => 10
+                 }
+               ],
+               "requestedQueryCost" => 10,
+               "throttleStatus" => %{
+                 "currentlyAvailable" => 990,
+                 "maximumAvailable" => 1.0e3,
+                 "restoreRate" => 50.0
+               }
+             }
+           },
+           response: %{
+             "metafield1" => %{
+               "deletedId" => "gid://shopify/Metafield/5256098316335",
+               "userErrors" => []
+             }
+           },
+           status_code: 200,
+           headers: [
+             {"cache-control", "max-age=0, private, must-revalidate"},
+             {"content-length", "352"},
+             {"date", "Tue, 20 Aug 2019 20:27:42 GMT"},
+             {"server", "Cowboy"}
+           ]
+         }}
+
+      assert success == Response.handle(@httpoison_response)
+    end
+
+    test "when request fails" do
+      error =
+        {:error,
+         %HTTPoison.Response{
+           body: [%{"message" => "Query has a cost of 1100, which exceeds the max cost of 1000"}],
+           headers: [
+             {"cache-control", "max-age=0, private, must-revalidate"},
+             {"content-length", "76"},
+             {"date", "Tue, 20 Aug 2019 20:30:20 GMT"},
+             {"server", "Cowboy"}
+           ],
+           request: %HTTPoison.Request{
+             body:
+               "mutation {\n    metafield1: metafieldDelete (input: {id: \"gid://shopify/Metafield/123456789\"}){\n    deletedId\n    userErrors {\n      field\n      message\n      }\n    }\n  }",
+             headers: [
+               {"Content-Type", "application/graphql"},
+               {"X-Shopify-Access-Token", "1234"}
+             ],
+             method: :post,
+             options: [
+               token: %ShopifyAPI.AuthToken{
+                 app_name: "",
+                 code: "",
+                 plus: false,
+                 shop_name: "localhost:60536",
+                 timestamp: 0,
+                 token: "1234"
+               }
+             ],
+             params: %{},
+             url: "http://localhost:60536/admin/api/2019-07/graphql.json"
+           },
+           request_url: "http://localhost:60536/admin/api/2019-07/graphql.json",
+           status_code: 200
+         }}
+
+      assert error == Response.handle(@httpoison_error_response)
+    end
+
+    test "when json decode fails" do
+      error =
+        {:error,
+         %ShopifyAPI.GraphQL.JSONParseError{
+           error: %Jason.DecodeError{
+             data: "{\"data\": null, \"errors\": }",
+             position: 25,
+             token: nil
+           },
+           response: %HTTPoison.Response{
+             body: "{\"data\": null, \"errors\": }",
+             headers: [],
+             request: nil,
+             request_url: nil,
+             status_code: nil
+           }
+         }}
+
+      payload = {:ok, %HTTPoison.Response{body: ~s/{"data": null, "errors": }/}}
+
+      assert error == Response.handle(payload)
+    end
+  end
+end

--- a/test/shopify_api/graphql/telemetry_test.exs
+++ b/test/shopify_api/graphql/telemetry_test.exs
@@ -1,0 +1,34 @@
+defmodule ShopifyAPI.GraphQL.TelemetryTest do
+  use ExUnit.Case
+
+  alias HTTPoison.Error
+  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.GraphQL.{Response, Telemetry}
+
+  @module "module"
+  @time 1202
+
+  setup _context do
+    token = %AuthToken{
+      token: "1234",
+      shop_name: "localhost"
+    }
+
+    {:ok, %{auth_token: token}}
+  end
+
+  describe "Telemetry send/4" do
+    test "when graphql response is succesful", %{auth_token: token} do
+      assert :ok == Telemetry.send(@module, token, @time, {:ok, %Response{response: "response"}})
+    end
+
+    test "when graphql request fails", %{auth_token: token} do
+      assert :ok ==
+               Telemetry.send(@module, token, @time, {:error, %Response{response: "response"}})
+    end
+
+    test "when graphql request errors out", %{auth_token: token} do
+      assert :ok == Telemetry.send(@module, token, @time, {:error, %Error{reason: "reason"}})
+    end
+  end
+end


### PR DESCRIPTION
This is a simple GraphQL implementation to handle GraphQL Queries against Shopify API using HTTPoison library as client, this initial implementation consists of hitting Shopify GraphQL and returning the response in a tuple `{:ok, %Response{}} | {:error, %Response{}}` containing the `response` and metadata(`actualQueryCost`, `throttleStatus`).

Transforms HTTPoison.Response into a %GraphQL.Response struct:

```
 %GraphQL.Response{
          response: Map.t(),
          metadata: Map.t(),
          status_code: Integer.t()
        }. 
```

* Testing from console - query string:
```
iex> auth = %ShopifyAPI.AuthToken{}
iex> query ="mutation {metafield0: metafieldDelete (input: {id: "gid://shopify/Metafield/9208558682200"}){deletedId userErrors {field message }}}"
iex> ShopifyAPI.GraphQL.query(auth, query)
```

* Testing from console - parametized query:
```
iex> auth = %ShopifyAPI.AuthToken{}
iex> query = "mutation metafieldDelete($input: MetafieldDeleteInput!){metafieldDelete(input: $input) {deletedId userErrors {field message }}}"
iex> opts = [variables: %{input: %{id: "gid://shopify/Metafield/9208558682200"}}]
iex> ShopifyAPI.GraphQL.query(auth, query, opts)
```
[ch53711]