### PR TITLE
Trace Metadata

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -46,6 +46,7 @@ config :exq,
     Exq.Middleware.Stats,
     Exq.Middleware.Job,
     Exq.Middleware.Manager,
+    ShopifyAPI.Middleware.MetadataLogger,
     Exq.Middleware.Logger,
     Exq.Middleware.AtomizeJobArguments,
     ShopifyAPI.Middleware.EventStructCoercer

--- a/lib/shopify_api/event_pipe/event.ex
+++ b/lib/shopify_api/event_pipe/event.ex
@@ -8,6 +8,7 @@ defmodule ShopifyAPI.EventPipe.Event do
             callback: nil,
             action: "none",
             assigns: %{},
+            metadata: %{},
             response: nil
 
   @type callback :: (ShopifyAPI.AuthToken.t(), t() -> any())
@@ -19,6 +20,7 @@ defmodule ShopifyAPI.EventPipe.Event do
           callback: nil | callback(),
           action: String.t(),
           assigns: map(),
+          metadata: map(),
           response: any()
         }
 end

--- a/lib/shopify_api/middleware/metadata_logger.ex
+++ b/lib/shopify_api/middleware/metadata_logger.ex
@@ -1,0 +1,29 @@
+defmodule ShopifyAPI.Middleware.MetadataLogger do
+  @moduledoc """
+  Applies the metadata stored the Event to the Logger.
+  """
+
+  @behaviour Exq.Middleware.Behaviour
+
+  require Logger
+
+  alias Exq.Middleware.Pipeline
+
+  def before_work(%Pipeline{assigns: %{job: %{args: args}}} = pipeline) do
+    Enum.each(args, &apply_metadata/1)
+    pipeline
+
+    # TODO assigns.job.jid
+  end
+
+  defp apply_metadata(%{metadata: metadata = %{}}) do
+    metadata
+    |> Enum.into([])
+    |> Logger.metadata()
+  end
+
+  defp apply_metadata(_event), do: nil
+
+  def after_processed_work(pipeline), do: pipeline
+  def after_failed_work(pipeline), do: pipeline
+end

--- a/lib/shopify_api/plugs/webhook.ex
+++ b/lib/shopify_api/plugs/webhook.ex
@@ -37,8 +37,13 @@ defmodule ShopifyAPI.Plugs.Webhook do
       app: conn.assigns.app,
       shop: Map.get(conn.assigns, :shop),
       action: conn.assigns.shopify_event,
-      object: conn.body_params
+      object: conn.body_params,
+      metadata: metadata()
     }
+  end
+
+  defp metadata do
+    Enum.into(Logger.metadata(), %{})
   end
 
   defp verify_and_parse(conn) do

--- a/test/shopify_api/middlewere/metadata_logger_test.exs
+++ b/test/shopify_api/middlewere/metadata_logger_test.exs
@@ -1,0 +1,54 @@
+defmodule ShopifyAPI.Middleware.MetadataLoggerTest do
+  use ExUnit.Case
+
+  require Logger
+
+  alias Exq.Middleware.Pipeline
+  alias ShopifyAPI.EventPipe.Event
+  alias ShopifyAPI.Middleware.MetadataLogger
+
+  defp build_pipeline(args) when is_list(args) do
+    %Pipeline{
+      assigns: %{
+        job: %{
+          args: args
+        }
+      }
+    }
+  end
+
+  defp build_pipeline(arg), do: build_pipeline([arg])
+
+  test "Not metadata in the Event leads to no metadata in the Logger" do
+    %Event{}
+    |> build_pipeline
+    |> MetadataLogger.before_work()
+
+    assert Logger.metadata() == []
+  end
+
+  test "Metadata in the Event leads to metadata in the Logger" do
+    request_id = "1234567890"
+
+    %Event{metadata: %{request_id: request_id}}
+    |> build_pipeline
+    |> MetadataLogger.before_work()
+
+    assert Logger.metadata() == [request_id: request_id]
+  end
+
+  test "A bunch of Metadata in the Event leads to metadata in the Logger" do
+    request_id = "1234567890"
+    meta1 = {:key, "value"}
+    meta2 = [{:key, "value"}]
+
+    %Event{metadata: %{request_id: request_id, meta1: meta1, meta2: meta2}}
+    |> build_pipeline
+    |> MetadataLogger.before_work()
+
+    metadata = Logger.metadata()
+    assert Keyword.get(metadata, :request_id) == request_id
+    assert Keyword.get(metadata, :meta1) == meta1
+    assert Keyword.get(metadata, :meta2) == meta2
+  end
+end


### PR DESCRIPTION
The impetus for this is to address ch55416. 
The main idea is to pass `Logger.metadata` through the system as much is practical to make logging simpler. 
* Existing `Logger.metadata` should be added to an Event when it is created. 
* Metadata on an Event should be added to `Logger.metadata` when processing

The biggest complication so far is that Exq middleware is not run in the same process that `perform` is run (see [here](https://github.com/akira/exq/blob/05c67195908d8eb3ae61c54b3422b56542f48ad8/lib/exq/worker/server.ex#L184)). 