### PR TITLE
remove cache servers from app start up and create new supervisor for …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Refactor caching servers startup, no longer started by ShopifyAPI.Application
+
 ## 0.6.0
 
 - Add internal GraphQL interface to Shopify's GraphQL API

--- a/lib/shopify_api/application.ex
+++ b/lib/shopify_api/application.ex
@@ -9,11 +9,7 @@ defmodule ShopifyAPI.Application do
     AvailabilityTracker.init()
 
     # Define workers and child supervisors to be supervised
-    children = [
-      ShopifyAPI.ShopServer,
-      ShopifyAPI.AppServer,
-      ShopifyAPI.AuthTokenServer
-    ]
+    children = []
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/shopify_api/cache_supervisor.ex
+++ b/lib/shopify_api/cache_supervisor.ex
@@ -1,0 +1,35 @@
+defmodule ShopifyAPI.CacheSupervisor do
+  @moduledoc """
+  The CacheSupervisor provides a convenient way to monitor, control, and start all the ShopifyAPI cache servers.
+
+  ## Using
+
+  Include the CacheSupervisor in your applications children after any dependencies, ie Ecto.
+
+  ```elixir
+  def start(_type, _args) do
+    # Define workers and child supervisors to be supervised
+    children = [
+      MyApp.Repo,
+      ShopifyAPI.CacheSupervisor
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+  ```
+  """
+  use Supervisor
+
+  def start_link(arg), do: Supervisor.start_link(__MODULE__, arg, name: __MODULE__)
+
+  @impl true
+  def init(_arg) do
+    children = [
+      ShopifyAPI.ShopServer,
+      ShopifyAPI.AppServer,
+      ShopifyAPI.AuthTokenServer
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -1,6 +1,6 @@
 defmodule ShopifyAPI.GraphQL do
   @moduledoc """
-  Interface to Shopify's GraphQL Admin API. 
+  Interface to Shopify's GraphQL Admin API.
   """
 
   require Logger
@@ -16,22 +16,21 @@ defmodule ShopifyAPI.GraphQL do
 
   @log_module __MODULE__ |> to_string() |> String.trim_leading("Elixir.")
 
-  @doc ~S[
+  @doc """
     Makes requests against Shopify GraphQL and returns a tuple containig
     a %Response struct with %{response, metadata, status_code}
-    
+
     ## Example
-    
+
       iex> query =  %{
-        operationName: "metafieldDelete", 
-        query: "mutation metafieldDelete($input: MetafieldDeleteInput!){metafieldDelete(input: $input) {deletedId userErrors {field message }}}", 
+        operationName: "metafieldDelete",
+        query: "mutation metafieldDelete($input: MetafieldDeleteInput!){metafieldDelete(input: $input) {deletedId userErrors {field message }}}",
         variables: %{input: %{id: "gid://shopify/Metafield/9208558682200"}}
       }
-      """
-    
+
       iex> ShopifyAPI.GraphQL.query(auth, query)
       {:ok, %Response{...}}
-    ]
+  """
   def query(%AuthToken{} = auth, query_string, variables \\ %{}, opts \\ []) do
     url = build_url(auth, opts)
     headers = build_headers(auth, opts)

--- a/test/shopify_api/plugs/admin_authenticator_test.exs
+++ b/test/shopify_api/plugs/admin_authenticator_test.exs
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticatorTest do
 
   alias Plug.Conn
   alias ShopifyAPI.Plugs.AdminAuthenticator
-  alias ShopifyAPI.{App, AppServer, AuthToken, AuthTokenServer, Shop, ShopServer}
+  alias ShopifyAPI.{App, AppServer, AuthToken, AuthTokenServer, CacheSupervisor, Shop, ShopServer}
 
   @app %App{name: "test"}
   @shop %Shop{domain: "test-shop.example.com"}
@@ -15,7 +15,8 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticatorTest do
     hmac: "2ebfc11fdbff86c17d688617e0ce54ca6ae1cf2a8ddcdcb2226dfbf8d02374e6"
   }
 
-  setup do
+  setup_all do
+    {:ok, _} = CacheSupervisor.start_link([])
     ShopServer.set(@shop)
     AppServer.set(@app)
     AuthTokenServer.set(@auth_token)

--- a/test/shopify_api/plugs/webhook_test.exs
+++ b/test/shopify_api/plugs/webhook_test.exs
@@ -4,7 +4,7 @@ defmodule ShopifyAPI.Plugs.WebhookTest do
 
   alias Plug.Conn
   alias ShopifyAPI.Plugs.Webhook
-  alias ShopifyAPI.{App, AppServer, JSONSerializer, Shop, ShopServer}
+  alias ShopifyAPI.{App, AppServer, CacheSupervisor, JSONSerializer, Shop, ShopServer}
 
   @app %App{name: "test"}
   @shop %Shop{domain: "test-shop.example.com"}
@@ -14,7 +14,8 @@ defmodule ShopifyAPI.Plugs.WebhookTest do
     send(self(), {:webhook_callback, v})
   end
 
-  setup do
+  setup_all do
+    {:ok, _} = CacheSupervisor.start_link([])
     Application.put_env(:shopify_api, :webhook_filter, {__MODULE__, :webhook_callback, []})
     ShopServer.set(@shop)
     AppServer.set(@app)

--- a/test/shopify_api/router_test.exs
+++ b/test/shopify_api/router_test.exs
@@ -2,7 +2,16 @@ defmodule Test.ShopifyAPI.RouterTest do
   use ExUnit.Case
   use Plug.Test
 
-  alias ShopifyAPI.{AppServer, AuthTokenServer, JSONSerializer, Router, Security, ShopServer}
+  alias ShopifyAPI.{
+    AppServer,
+    AuthTokenServer,
+    CacheSupervisor,
+    JSONSerializer,
+    Router,
+    Security,
+    ShopServer
+  }
+
   alias Plug.{Conn, Parsers}
 
   @moduletag :capture_log
@@ -18,7 +27,9 @@ defmodule Test.ShopifyAPI.RouterTest do
   @redirect_uri "example.com"
   @shop_domain "shop.example.com"
 
-  setup do
+  setup_all do
+    {:ok, _} = CacheSupervisor.start_link([])
+
     AppServer.set(@app_name, %{
       auth_redirect_uri: @redirect_uri,
       client_secret: @client_secret,
@@ -28,6 +39,7 @@ defmodule Test.ShopifyAPI.RouterTest do
     })
 
     ShopServer.set(%{domain: @shop_domain})
+    :ok
   end
 
   describe "/install" do


### PR DESCRIPTION
remove cache servers from app start up and create new supervisor for  them

- the beginnings of what we talked about for separating ShopifyAPI startup and the cache servers.

WARNING: This change will break previous uses of this library. The quick fix is to add the CacheSupervisor in to your apps children and have it started explicitly.