### PR TITLE
Fix Shopify Error Handling for GraphQL Requests

### DIFF
--- a/lib/shopify_api/graphql/response.ex
+++ b/lib/shopify_api/graphql/response.ex
@@ -37,6 +37,8 @@ defmodule ShopifyAPI.GraphQL.Response do
   def handle({:error, _} = response, _), do: response
 
   @doc false
+  def build_response(%{body: %{"data" => nil}} = response), do: {:error, response}
+
   def build_response(%{body: %{"data" => data, "extensions" => extensions}} = response) do
     {
       :ok,


### PR DESCRIPTION
# Whats the Issue?
Fixes an issue that when Shopify denies a GraphQL request (in this case incorrect permissions) the the raw response is 
```
{
  "data":null,
  "errors":[
    {
      "message":"access denied",
      "locations":[{"line":2,"column":3}],
      "path":["codeDiscountNodes"]
   }
  ],
  "extensions":<stuff>
}
```

ShopifyAPI is matching on the existance of the `data` key, but Shopify is nicely(?) including that with the value of null, so the API still matches and therefore responses with
```
{:ok,
 %ShopifyAPI.GraphQL.Response{
   ... 
   response: %{"codeDiscountNodeByCode" => nil},
   status_code: 200
 }}
```
Where it should be recognizing this as an error state and returning the entire response in an error tuple.

# How does this fix it?
Adds a guard to the `build_response` function against the data argument having a nil value.
