### PR TITLE
Remove email address from the Customer Authenticator token

### DIFF
--- a/lib/shopify_api/plugs/customer_authenticator.ex
+++ b/lib/shopify_api/plugs/customer_authenticator.ex
@@ -8,7 +8,7 @@ defmodule ShopifyAPI.Plugs.CustomerAuthenticator do
   ```liquid
     {% assign auth_expiry = "now" | date: "%s" | plus: 3600 | date: "%Y-%m-%dT%H:%M:%S.%L%z" %}
     {% capture json_string %}
-      {"email":"{{ customer.email }}","id":"{{ customer.id }}","expiry":"{{ auth_expiry }}"}
+      {"id":"{{ customer.id }}","expiry":"{{ auth_expiry }}"}
     {% endcapture %}
     {% assign AUTH_PAYLOAD = json_string | strip %}
     {% assign AUTH_SIGNATURE = AUTH_PAYLOAD | hmac_sha256: settings.secret %}


### PR DESCRIPTION
This change updates the documentation for `ShopifyAPI.Plugs.CustomerAuthenticator` to remove the email address from the JSON token. This key is not being used and since it constitutes PII, should ideally not be included in the token. The `id` element is already part of the token and can serve as a unique customer identifier instead.