### PR TITLE
Optional params arg to appropriate GET resources

### DIFF
--- a/lib/shopify_api/rest.ex
+++ b/lib/shopify_api/rest.ex
@@ -12,8 +12,8 @@ defmodule ShopifyAPI.REST do
   alias ShopifyAPI.REST.Request
 
   @doc false
-  def get(%AuthToken{} = auth, path) do
-    Request.perform(auth, :get, path)
+  def get(%AuthToken{} = auth, path, params \\ []) do
+    Request.perform(auth, :get, path, "", params)
   end
 
   @doc false

--- a/lib/shopify_api/rest/access_scope.ex
+++ b/lib/shopify_api/rest/access_scope.ex
@@ -14,5 +14,6 @@ defmodule ShopifyAPI.REST.AccessScope do
       iex> ShopifyAPI.REST.AccessScope.get(auth)
       {:ok, %{ "access_scopes" => [] }}
   """
-  def get(%AuthToken{} = auth), do: REST.get(auth, "oauth/access_scopes.json")
+  def get(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "oauth/access_scopes.json", params)
 end

--- a/lib/shopify_api/rest/application_charge.ex
+++ b/lib/shopify_api/rest/application_charge.ex
@@ -28,8 +28,8 @@ defmodule ShopifyAPI.REST.ApplicationCharge do
       iex> ShopifyAPI.REST.ApplicationCharge.get(auth, integer)
       {:ok, { "application_charge" => %{} }}
   """
-  def get(%AuthToken{} = auth, application_charge_id),
-    do: REST.get(auth, "application_charges/#{application_charge_id}.json")
+  def get(%AuthToken{} = auth, application_charge_id, params \\ []),
+    do: REST.get(auth, "application_charges/#{application_charge_id}.json", params)
 
   @doc """
   Get a list of all application charges.
@@ -39,7 +39,8 @@ defmodule ShopifyAPI.REST.ApplicationCharge do
       iex> ShopifyAPI.REST.ApplicationCharge.all(auth)
       {:ok, { "application_charges" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "application_charges.json")
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "application_charges.json", params)
 
   @doc """
   Active an application charge.

--- a/lib/shopify_api/rest/application_credit.ex
+++ b/lib/shopify_api/rest/application_credit.ex
@@ -25,8 +25,8 @@ defmodule ShopifyAPI.REST.ApplicationCredit do
       iex> ShopifyAPI.REST.ApplicationCredit.get(auth, integer)
       {:ok, { "application_credit" => %{} }}
   """
-  def get(%AuthToken{} = auth, application_credit_id),
-    do: REST.get(auth, "application_credits/#{application_credit_id}.json")
+  def get(%AuthToken{} = auth, application_credit_id, params \\ []),
+    do: REST.get(auth, "application_credits/#{application_credit_id}.json", params)
 
   @doc """
   Get a list of all application credits.
@@ -36,5 +36,6 @@ defmodule ShopifyAPI.REST.ApplicationCredit do
       iex> ShopifyAPI.REST.ApplicationCredit.all(auth)
       {:ok, { "application_credits" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "application_credits.json")
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "application_credits.json", params)
 end

--- a/lib/shopify_api/rest/asset.ex
+++ b/lib/shopify_api/rest/asset.ex
@@ -14,8 +14,8 @@ defmodule ShopifyAPI.REST.Asset do
       iex> ShopifyAPI.REST.Asset.get(auth, integer, params)
       {:ok, { "asset" => %{} }}
   """
-  def get(%AuthToken{} = auth, theme_id, params),
-    do: REST.get(auth, "themes/#{theme_id}/assets.json?" <> URI.encode_query(params))
+  def get(%AuthToken{} = auth, theme_id, params \\ []),
+    do: REST.get(auth, "themes/#{theme_id}/assets.json", params)
 
   @doc """
   Return a list of all theme assets.
@@ -25,7 +25,8 @@ defmodule ShopifyAPI.REST.Asset do
       iex> ShopifyAPI.REST.Asset.all(auth, theme_id)
       {:ok, { "assets" => [] }}
   """
-  def all(%AuthToken{} = auth, theme_id), do: REST.get(auth, "themes/#{theme_id}/assets.json")
+  def all(%AuthToken{} = auth, theme_id, params \\ []),
+    do: REST.get(auth, "themes/#{theme_id}/assets.json", params)
 
   @doc """
   Update a theme asset.

--- a/lib/shopify_api/rest/carrier_service.ex
+++ b/lib/shopify_api/rest/carrier_service.ex
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.CarrierService do
       iex> ShopifyAPI.REST.CarrierService.all(auth)
       {:ok, { "carrier_services" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "carrier_services.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "carrier_services.json", params)
 
   @doc """
   Get a single carrier service.
@@ -24,8 +24,8 @@ defmodule ShopifyAPI.REST.CarrierService do
       iex> ShopifyAPI.REST.CarrierService.get(auth, string)
       {:ok, { "carrier_service" => %{} }}
   """
-  def get(%AuthToken{} = auth, carrier_service_id),
-    do: REST.get(auth, "carrier_services/#{carrier_service_id}.json")
+  def get(%AuthToken{} = auth, carrier_service_id, params \\ []),
+    do: REST.get(auth, "carrier_services/#{carrier_service_id}.json", params)
 
   @doc """
   Create a carrier service.

--- a/lib/shopify_api/rest/collect.ex
+++ b/lib/shopify_api/rest/collect.ex
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.Collect do
       iex> ShopifyAPI.REST.Collect.all(auth)
       {:ok, %{ "collects" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "collects.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "collects.json", params)
 
   @doc """
   Get a count of collects.
@@ -46,7 +46,7 @@ defmodule ShopifyAPI.REST.Collect do
       iex> ShopifyAPI.REST.Collect.count(auth)
       {:ok, %{ "count" => 123 }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "collects/count.json")
+  def count(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "collects/count.json", params)
 
   @doc """
   Get a specific collect.
@@ -56,5 +56,6 @@ defmodule ShopifyAPI.REST.Collect do
       iex> ShopifyAPI.REST.Collect.get(auth, id)
       {:ok, %{ "collect" => %{} }}
   """
-  def get(%AuthToken{} = auth, collect_id), do: REST.get(auth, "collects/#{collect_id}.json")
+  def get(%AuthToken{} = auth, collect_id, params \\ []),
+    do: REST.get(auth, "collects/#{collect_id}.json", params)
 end

--- a/lib/shopify_api/rest/custom_collection.ex
+++ b/lib/shopify_api/rest/custom_collection.ex
@@ -13,7 +13,8 @@ defmodule ShopifyAPI.REST.CustomCollection do
       iex> ShopifyAPI.REST.CustomCollection.all(token)
       {:ok, %{ "custom_collections" => %{} }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "admin/custom_collections.json")
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "admin/custom_collections.json", params)
 
   @doc """
   Get a count of all custom collections.
@@ -22,7 +23,8 @@ defmodule ShopifyAPI.REST.CustomCollection do
       iex> ShopifyAPI.REST.CustomCollection.count(token)
       {:ok, { "count": integer }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "custom_collections/count.json")
+  def count(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "custom_collections/count.json", params)
 
   @doc """
   Return a single custom collection.
@@ -31,8 +33,8 @@ defmodule ShopifyAPI.REST.CustomCollection do
       iex> ShopifyAPI.REST.CustomCollection.get(auth, string)
       {:ok, %{ "custom_collections" => %{} }}
   """
-  def get(%AuthToken{} = auth, custom_collection_id),
-    do: REST.get(auth, "custom_collections/#{custom_collection_id}.json")
+  def get(%AuthToken{} = auth, custom_collection_id, params \\ []),
+    do: REST.get(auth, "custom_collections/#{custom_collection_id}.json", params)
 
   @doc """
   Create a custom collection.

--- a/lib/shopify_api/rest/customer.ex
+++ b/lib/shopify_api/rest/customer.ex
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.Customer do
       iex> ShopifyAPI.REST.Customer.all(auth)
       {:ok, {"customers" => []}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "customers.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "customers.json", params)
 
   @doc """
   Return a single customer.
@@ -25,8 +25,8 @@ defmodule ShopifyAPI.REST.Customer do
       iex> ShopifyAPI.REST.Customer.get(auth, integer)
       {:ok, {"customer" = > %{}}
   """
-  def get(%AuthToken{} = auth, customer_id),
-    do: REST.get(auth, "customers/#{customer_id}.json")
+  def get(%AuthToken{} = auth, customer_id, params \\ []),
+    do: REST.get(auth, "customers/#{customer_id}.json", params)
 
   @doc """
   Return a customers that match supplied query.
@@ -109,7 +109,7 @@ defmodule ShopifyAPI.REST.Customer do
       iex> ShopifyAPI.REST.Customer.count(auth)
       {:ok, {"count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "customers/count.json")
+  def count(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "customers/count.json", params)
 
   @doc """
   Return all orders from a customer.
@@ -119,8 +119,8 @@ defmodule ShopifyAPI.REST.Customer do
       iex> ShopifyAPI.REST.Customer.GetOrder(auth, integer)
       {:ok, {"orders" => [] }}
   """
-  def get_orders(%AuthToken{} = auth, customer_id),
-    do: REST.get(auth, "customers/#{customer_id}/orders.json")
+  def get_orders(%AuthToken{} = auth, customer_id, params \\ []),
+    do: REST.get(auth, "customers/#{customer_id}/orders.json", params)
 
   @doc """
   Search for customers that match a supplied query
@@ -135,6 +135,7 @@ defmodule ShopifyAPI.REST.Customer do
   %{"query" => "country:Canada"} - returns all customers with an address in Canada
   %{"query" => "Bob country:Canada"} - returns all customers with an address in Canada and the name "Bob"
   """
+  # TODO (BJ) - Consider refactoring to use a KW List of options params
   def search(%AuthToken{} = auth, params),
-    do: REST.get(auth, "customers/search.json?" <> URI.encode_query(params))
+    do: REST.get(auth, "customers/search.json", params)
 end

--- a/lib/shopify_api/rest/customer_address.ex
+++ b/lib/shopify_api/rest/customer_address.ex
@@ -15,8 +15,8 @@ defmodule ShopifyAPI.REST.CustomerAddress do
       iex> ShopifyAPI.REST.CustomerAddress.all(auth, string)
       {:ok, %{ "addresses" => [] }}
   """
-  def all(%AuthToken{} = auth, customer_id),
-    do: REST.get(auth, "customers/#{customer_id}/addresses.json")
+  def all(%AuthToken{} = auth, customer_id, params \\ []),
+    do: REST.get(auth, "customers/#{customer_id}/addresses.json", params)
 
   @doc """
   Return a single address for a customer.
@@ -26,8 +26,8 @@ defmodule ShopifyAPI.REST.CustomerAddress do
       iex> ShopifyAPI.REST.CustomerAddress.get(auth, string, string)
       {:ok, %{ "customer_address" => %{} }}
   """
-  def get(%AuthToken{} = auth, customer_id, address_id),
-    do: REST.get(auth, "customers/#{customer_id}/addresses/#{address_id}.json")
+  def get(%AuthToken{} = auth, customer_id, address_id, params \\ []),
+    do: REST.get(auth, "customers/#{customer_id}/addresses/#{address_id}.json", params)
 
   @doc """
   Create a new address for a customer.

--- a/lib/shopify_api/rest/discount_code.ex
+++ b/lib/shopify_api/rest/discount_code.ex
@@ -49,8 +49,8 @@ defmodule ShopifyAPI.REST.DiscountCode do
       iex> ShopifyAPI.REST.DiscountCode.all(auth, integer)
       {:ok, { "discount_codes" => [] }}
   """
-  def all(%AuthToken{} = auth, price_rule_id) do
-    REST.get(auth, "price_rules/#{price_rule_id}/discount_codes.json")
+  def all(%AuthToken{} = auth, price_rule_id, params \\ []) do
+    REST.get(auth, "price_rules/#{price_rule_id}/discount_codes.json", params)
   end
 
   @doc """
@@ -61,8 +61,13 @@ defmodule ShopifyAPI.REST.DiscountCode do
       iex> ShopifyAPI.REST.DiscountCode.get(auth, integer, integer)
       {:ok, { "discount_code" => %{} }}
   """
-  def get(%AuthToken{} = auth, price_rule_id, discount_code_id),
-    do: REST.get(auth, "price_rules/#{price_rule_id}/discount_codes/#{discount_code_id}.json")
+  def get(%AuthToken{} = auth, price_rule_id, discount_code_id, params \\ []),
+    do:
+      REST.get(
+        auth,
+        "price_rules/#{price_rule_id}/discount_codes/#{discount_code_id}.json",
+        params
+      )
 
   @doc """
   Retrieve the location of a discount code.
@@ -72,6 +77,9 @@ defmodule ShopifyAPI.REST.DiscountCode do
       iex> ShopifyAPI.REST.DiscountCode.query(auth, string)
       {:ok, { "location" => "" }}
   """
+  # TODO (BJ) - This could be refactored to use the query params helpers
+  # iex> ShopifyAPI.REST.DiscountCode.query(auth, code: coupon_code)
+  # {:ok, { "location" => "" }}
   def query(%AuthToken{} = auth, coupon_code),
     do: REST.get(auth, "discount_codes/lookup.json?code=#{coupon_code}")
 
@@ -105,8 +113,8 @@ defmodule ShopifyAPI.REST.DiscountCode do
       iex> ShopifyAPI.REST.DiscountCode.get_batch(auth, integer, integer)
       {:ok, "discount_code_creation" => %{} }
   """
-  def get_batch(%AuthToken{} = auth, price_rule_id, batch_id),
-    do: REST.get(auth, "price_rules/#{price_rule_id}/batch/#{batch_id}.json")
+  def get_batch(%AuthToken{} = auth, price_rule_id, batch_id, params \\ []),
+    do: REST.get(auth, "price_rules/#{price_rule_id}/batch/#{batch_id}.json", params)
 
   @doc """
   Return a list of discount codes for a discount code creation job.
@@ -116,6 +124,8 @@ defmodule ShopifyAPI.REST.DiscountCode do
       iex> ShopifyAPI.REST.DiscountCode.all_batch(auth, integer, integer)
       {:ok, "discount_codes" => [] }
   """
-  def all_batch(%AuthToken{} = auth, price_rule_id, batch_id),
-    do: REST.get(auth, "price_rules/#{price_rule_id}/batch/#{batch_id}/discount_code.json")
+  def(all_batch(%AuthToken{} = auth, price_rule_id, batch_id, params \\ []),
+    do:
+      REST.get(auth, "price_rules/#{price_rule_id}/batch/#{batch_id}/discount_code.json", params)
+  )
 end

--- a/lib/shopify_api/rest/draft_order.ex
+++ b/lib/shopify_api/rest/draft_order.ex
@@ -45,7 +45,7 @@ defmodule ShopifyAPI.REST.DraftOrder do
       iex> ShopifyAPI.REST.DraftOrder.all(auth)
       {:ok, %{"draft_orders" => []}}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "draft_orders.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "draft_orders.json", params)
 
   @doc """
   Retrieve a specific draft order
@@ -55,8 +55,8 @@ defmodule ShopifyAPI.REST.DraftOrder do
       iex> ShopifyAPI.REST.DraftOrder.get(auth, integer)
       {:ok, %{"draft_order" => %{...}}}
   """
-  def get(%AuthToken{} = auth, draft_order_id),
-    do: REST.get(auth, "draft_orders/#{draft_order_id}.json")
+  def get(%AuthToken{} = auth, draft_order_id, params \\ []),
+    do: REST.get(auth, "draft_orders/#{draft_order_id}.json", params)
 
   @doc """
   Retrieve a count of all draft orders
@@ -66,7 +66,8 @@ defmodule ShopifyAPI.REST.DraftOrder do
       iex> ShopifyAPI.REST.DraftOrder.count(auth)
       {:ok, %{count: integer}}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "draft_orders/count.json")
+  def count(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "draft_orders/count.json", params)
 
   @doc """
   Send an invoice for a draft order

--- a/lib/shopify_api/rest/event.ex
+++ b/lib/shopify_api/rest/event.ex
@@ -16,7 +16,7 @@ defmodule ShopifyAPI.REST.Event do
       iex> ShopifyAPI.REST.Event.all(auth)
       {:ok, { "events" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "events.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "events.json", params)
 
   @doc """
   Get a single event.
@@ -26,7 +26,8 @@ defmodule ShopifyAPI.REST.Event do
       iex> ShopifyAPI.REST.Event.get(auth, integer)
       {:ok, { "event" => %{} }}
   """
-  def get(%AuthToken{} = auth, event_id), do: REST.get(auth, "events/#{event_id}.json")
+  def get(%AuthToken{} = auth, event_id, params \\ []),
+    do: REST.get(auth, "events/#{event_id}.json", params)
 
   @doc """
   Get a count of all Events.
@@ -36,5 +37,5 @@ defmodule ShopifyAPI.REST.Event do
       iex> ShopifyAPI.REST.Event.count(auth)
       {:ok, { "events" => integer }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "events/count.json")
+  def count(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "events/count.json", params)
 end

--- a/lib/shopify_api/rest/fulfillment.ex
+++ b/lib/shopify_api/rest/fulfillment.ex
@@ -14,8 +14,8 @@ defmodule ShopifyAPI.REST.Fulfillment do
       iex> ShopifyAPI.REST.Fulfillment.all(auth, string)
       {:ok, { "fulfillments" => [] }}
   """
-  def all(%AuthToken{} = auth, order_id),
-    do: REST.get(auth, "orders/#{order_id}/fulfillments.json")
+  def all(%AuthToken{} = auth, order_id, params \\ []),
+    do: REST.get(auth, "orders/#{order_id}/fulfillments.json", params)
 
   @doc """
   Return a count of all fulfillments.
@@ -25,8 +25,8 @@ defmodule ShopifyAPI.REST.Fulfillment do
       iex> ShopifyAPI.REST.Fulfillment.count(auth, string)
       {:ok, { "count" => integer }}
   """
-  def count(%AuthToken{} = auth, order_id),
-    do: REST.get(auth, "orders/#{order_id}/fulfillments/count.json")
+  def count(%AuthToken{} = auth, order_id, params \\ []),
+    do: REST.get(auth, "orders/#{order_id}/fulfillments/count.json", params)
 
   @doc """
   Get a single fulfillment.
@@ -36,8 +36,8 @@ defmodule ShopifyAPI.REST.Fulfillment do
       iex> ShopifyAPI.REST.Fulfillment.get(auth, string, string)
       {:ok, { "fulfillment" => %{} }}
   """
-  def get(%AuthToken{} = auth, order_id, fulfillment_id),
-    do: REST.get(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}.json")
+  def get(%AuthToken{} = auth, order_id, fulfillment_id, params \\ []),
+    do: REST.get(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}.json", params)
 
   @doc """
   Create a new fulfillment.

--- a/lib/shopify_api/rest/fulfillment_event.ex
+++ b/lib/shopify_api/rest/fulfillment_event.ex
@@ -14,8 +14,8 @@ defmodule ShopifyAPI.REST.FulfillmentEvent do
       iex> ShopifyAPI.REST.FulfillmentEvent.all(auth, string, string)
       {:ok, { "fulfillment_events" => [] }}
   """
-  def all(%AuthToken{} = auth, order_id, fulfillment_id),
-    do: REST.get(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}/events.json")
+  def all(%AuthToken{} = auth, order_id, fulfillment_id, params \\ []),
+    do: REST.get(auth, "orders/#{order_id}/fulfillments/#{fulfillment_id}/events.json", params)
 
   @doc """
   Get a single fulfillment event.
@@ -25,11 +25,12 @@ defmodule ShopifyAPI.REST.FulfillmentEvent do
       iex> ShopifyAPI.REST.FulfillmentEvent.get(auth, string, string, string)
       {:ok, { "fulfillment_event" => %{} }}
   """
-  def get(%AuthToken{} = auth, order_id, fulfillment_id, event_id),
+  def get(%AuthToken{} = auth, order_id, fulfillment_id, event_id, params \\ []),
     do:
       REST.get(
         auth,
-        "orders/#{order_id}/fulfillments/#{fulfillment_id}/events/#{event_id}.json"
+        "orders/#{order_id}/fulfillments/#{fulfillment_id}/events/#{event_id}.json",
+        params
       )
 
   @doc """

--- a/lib/shopify_api/rest/fulfillment_service.ex
+++ b/lib/shopify_api/rest/fulfillment_service.ex
@@ -14,7 +14,8 @@ defmodule ShopifyAPI.REST.FulfillmentService do
       iex> ShopifyAPI.REST.FulfillmentService.all(auth)
       {:ok, { "fulfillment_services" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "fulfillment_services.json")
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "fulfillment_services.json", params)
 
   @doc """
   Get a single fulfillment service.
@@ -24,8 +25,8 @@ defmodule ShopifyAPI.REST.FulfillmentService do
       iex> ShopifyAPI.REST.FulfillmentService.get(auth, string)
       {:ok, { "fulfillment_service" => %{} }}
   """
-  def get(%AuthToken{} = auth, fulfillment_service_id),
-    do: REST.get(auth, "fulfillment_services/#{fulfillment_service_id}.json")
+  def get(%AuthToken{} = auth, fulfillment_service_id, params \\ []),
+    do: REST.get(auth, "fulfillment_services/#{fulfillment_service_id}.json", params)
 
   @doc """
   Create a new fulfillment service.

--- a/lib/shopify_api/rest/inventory_item.ex
+++ b/lib/shopify_api/rest/inventory_item.ex
@@ -29,8 +29,8 @@ defmodule ShopifyAPI.REST.InventoryItem do
       iex> ShopifyAPI.REST.InventoryItem.get(auth, integer)
       {:ok, { "inventory_item" => %{} }}
   """
-  def get(%AuthToken{} = auth, inventory_item_id),
-    do: REST.get(auth, "inventory_items/#{inventory_item_id}.json")
+  def get(%AuthToken{} = auth, inventory_item_id, params \\ []),
+    do: REST.get(auth, "inventory_items/#{inventory_item_id}.json", params)
 
   @doc """
   Update an existing inventory item.

--- a/lib/shopify_api/rest/inventory_level.ex
+++ b/lib/shopify_api/rest/inventory_level.ex
@@ -13,7 +13,7 @@ defmodule ShopifyAPI.REST.InventoryLevel do
       iex> ShopifyAPI.REST.InventoryLevel.all(auth)
       {:ok, { "inventory_level" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "inventory_levels.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "inventory_levels.json", params)
 
   @doc """
   Sets the inventory level for an inventory item at a location.

--- a/lib/shopify_api/rest/location.ex
+++ b/lib/shopify_api/rest/location.ex
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.Location do
       iex> ShopifyAPI.REST.Location.all(auth)
       {:ok, { "locations" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "locations.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "locations.json", params)
 
   @doc """
   Return a single location.
@@ -24,8 +24,8 @@ defmodule ShopifyAPI.REST.Location do
     iex> ShopifyAPI.REST.Location.get(auth, integer)
     {:ok, %{ "location" => %{} }}
   """
-  def get(%AuthToken{} = auth, location_id),
-    do: REST.get(auth, "locations/#{location_id}.json")
+  def get(%AuthToken{} = auth, location_id, params \\ []),
+    do: REST.get(auth, "locations/#{location_id}.json", params)
 
   @doc """
   Return a count of locations.
@@ -35,7 +35,7 @@ defmodule ShopifyAPI.REST.Location do
     iex> ShopifyAPI.REST.Location.count(auth)
     {:ok, %{ "count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "locations/count.json")
+  def count(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "locations/count.json", params)
 
   @doc """
   Returns a list of inventory levels for a location.
@@ -45,6 +45,6 @@ defmodule ShopifyAPI.REST.Location do
     iex> ShopifyAPI.REST.Location.inventory_levels(auth, integer)
     {:ok, %{ "inventory_levels" => %{} }}
   """
-  def inventory_levels(%AuthToken{} = auth, location_id),
-    do: REST.get(auth, "locations/#{location_id}/inventory_levels.json")
+  def inventory_levels(%AuthToken{} = auth, location_id, params \\ []),
+    do: REST.get(auth, "locations/#{location_id}/inventory_levels.json", params)
 end

--- a/lib/shopify_api/rest/marketing_event.ex
+++ b/lib/shopify_api/rest/marketing_event.ex
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.MarketingEvent do
       iex> ShopifyAPI.REST.MarketingEvent.all(auth)
       {:ok, { "marketing_events" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "marketing_events.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "marketing_events.json", params)
 
   @doc """
   Get a count of all marketing events.
@@ -25,7 +25,8 @@ defmodule ShopifyAPI.REST.MarketingEvent do
       iex> ShopifyAPI.REST.MarketingEvent.count(auth)
       {:ok, { "count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "marketing_events/count.json")
+  def count(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "marketing_events/count.json", params)
 
   @doc """
   Get a single marketing event.
@@ -35,8 +36,8 @@ defmodule ShopifyAPI.REST.MarketingEvent do
       iex> ShopifyAPI.REST.MarketingEvent.get(auth, integer)
       {:ok, { "marketing_event" => %{} }}
   """
-  def get(%AuthToken{} = auth, marketing_event_id),
-    do: REST.get(auth, "marketing_events/#{marketing_event_id}.json")
+  def get(%AuthToken{} = auth, marketing_event_id, params \\ []),
+    do: REST.get(auth, "marketing_events/#{marketing_event_id}.json", params)
 
   @doc """
   Create a marketing event.

--- a/lib/shopify_api/rest/metafield.ex
+++ b/lib/shopify_api/rest/metafield.ex
@@ -23,11 +23,11 @@ defmodule ShopifyAPI.REST.Metafield do
     iex> ShopifyAPI.REST.Metafields.all(token, atom, integer)
     {:ok, %{ "metafields" => [] }}
   """
-  def all(%AuthToken{} = auth, params \\ %{}),
-    do: REST.get(auth, "metafields.json?" <> URI.encode_query(params))
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "metafields.json", params)
 
-  def all(%AuthToken{} = auth, type, resource_id, params \\ %{}),
-    do: REST.get(auth, resource_path(type, resource_id) <> "?" <> URI.encode_query(params))
+  def all(%AuthToken{} = auth, type, resource_id, params \\ []),
+    do: REST.get(auth, resource_path(type, resource_id), params)
 
   @doc """
   Return a count of metafields that belong to a Shop resource.
@@ -37,7 +37,8 @@ defmodule ShopifyAPI.REST.Metafield do
     iex> ShopifyAPI.REST.Metafields.count(token)
     {:ok, %{ "count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "metafields/count.json")
+  def count(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "metafields/count.json", params)
 
   @doc """
   Return a count that belong to a resource and its metafields.
@@ -47,8 +48,8 @@ defmodule ShopifyAPI.REST.Metafield do
     iex> ShopifyAPI.REST.Metafields.count(auth, atom, integer)
     {:ok, %{ "count" => integer }}
   """
-  def count(%AuthToken{} = auth, type, resource_id),
-    do: REST.get(auth, resource_path(type, resource_id))
+  def count(%AuthToken{} = auth, type, resource_id, params \\ []),
+    do: REST.get(auth, resource_path(type, resource_id), params)
 
   @doc """
   Return a list of metafields for a resource by it's ID.
@@ -58,8 +59,8 @@ defmodule ShopifyAPI.REST.Metafield do
     iex> ShopifyAPI.REST.Metafields.get(auth, atom, integer)
     {:ok, %{ "metafields" => [] }}
   """
-  def get(%AuthToken{} = auth, type, resource_id),
-    do: REST.get(auth, resource_path(type, resource_id))
+  def get(%AuthToken{} = auth, type, resource_id, params \\ []),
+    do: REST.get(auth, resource_path(type, resource_id), params)
 
   @doc """
   Creates a new metafield.

--- a/lib/shopify_api/rest/order.ex
+++ b/lib/shopify_api/rest/order.ex
@@ -9,7 +9,8 @@ defmodule ShopifyAPI.REST.Order do
   @doc """
     Return a single Order.
   """
-  def get(%AuthToken{} = auth, order_id), do: REST.get(auth, "orders/#{order_id}.json")
+  def get(%AuthToken{} = auth, order_id, params \\ []),
+    do: REST.get(auth, "orders/#{order_id}.json", params)
 
   @doc """
     Return all of a shops Orders filtered by query parameters.
@@ -49,7 +50,7 @@ defmodule ShopifyAPI.REST.Order do
   iex> ShopifyAPI.REST.Order.get(token)
   {:ok, %{"count" => integer}}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "orders/count.json")
+  def count(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "orders/count.json", params)
 
   @doc """
     Close an Order.

--- a/lib/shopify_api/rest/order.ex
+++ b/lib/shopify_api/rest/order.ex
@@ -15,7 +15,7 @@ defmodule ShopifyAPI.REST.Order do
     Return all of a shops Orders filtered by query parameters.
 
   iex> ShopifyAPI.REST.Order.all(token)
-  iex> ShopifyAPI.REST.Order.all(auth, %{param1: "value", param2: "value2"})
+  iex> ShopifyAPI.REST.Order.all(auth, [param1: "value", param2: "value2"])
   """
   def all(%AuthToken{} = auth, params \\ []),
     do: REST.get(auth, "orders.json", params)

--- a/lib/shopify_api/rest/order.ex
+++ b/lib/shopify_api/rest/order.ex
@@ -17,8 +17,8 @@ defmodule ShopifyAPI.REST.Order do
   iex> ShopifyAPI.REST.Order.all(token)
   iex> ShopifyAPI.REST.Order.all(auth, %{param1: "value", param2: "value2"})
   """
-  def all(%AuthToken{} = auth, params \\ %{}),
-    do: REST.get(auth, "orders.json?" <> URI.encode_query(params))
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "orders.json", params)
 
   @doc """
     Delete an Order.

--- a/lib/shopify_api/rest/price_rule.ex
+++ b/lib/shopify_api/rest/price_rule.ex
@@ -36,7 +36,7 @@ defmodule ShopifyAPI.REST.PriceRule do
       iex> ShopifyAPI.REST.PriceRule.all(auth)
       {:ok, { "price_rules" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "price_rules.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "price_rules.json", params)
 
   @doc """
   Get a single price rule.
@@ -46,8 +46,8 @@ defmodule ShopifyAPI.REST.PriceRule do
       iex> ShopifyAPI.REST.PriceRule.get(auth, integer)
       {:ok, { "price_rule" => %{} }}
   """
-  def get(%AuthToken{} = auth, price_rule_id),
-    do: REST.get(auth, "price_rules/#{price_rule_id}.json")
+  def get(%AuthToken{} = auth, price_rule_id, params \\ []),
+    do: REST.get(auth, "price_rules/#{price_rule_id}.json", params)
 
   @doc """
   Delete a price rule.

--- a/lib/shopify_api/rest/product.ex
+++ b/lib/shopify_api/rest/product.ex
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.Product do
     iex> ShopifyAPI.REST.Product.all(auth)
     {:ok, %{ "products" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "products.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "products.json", params)
 
   @doc """
   Return a single product.
@@ -24,7 +24,8 @@ defmodule ShopifyAPI.REST.Product do
     iex> ShopifyAPI.REST.Product.get(auth, integer)
     {:ok, %{ "product" => %{} }}
   """
-  def get(%AuthToken{} = auth, product_id), do: REST.get(auth, "products/#{product_id}.json")
+  def get(%AuthToken{} = auth, product_id, params \\ []),
+    do: REST.get(auth, "products/#{product_id}.json", params)
 
   @doc """
   Return a count of products.
@@ -34,7 +35,7 @@ defmodule ShopifyAPI.REST.Product do
     iex> ShopifyAPI.REST.Product.count(auth)
     {:ok, %{ "count" => integer }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "products/count.json")
+  def count(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "products/count.json", params)
 
   @doc """
   Update a product.

--- a/lib/shopify_api/rest/product_image.ex
+++ b/lib/shopify_api/rest/product_image.ex
@@ -14,8 +14,8 @@ defmodule ShopifyAPI.REST.ProductImage do
       iex> ShopifyApi.Rest.ProductImage.all(auth, integer)
       {:ok, { "images" => [] }}
   """
-  def all(%AuthToken{} = auth, product_id),
-    do: REST.get(auth, "products/#{product_id}/images.json")
+  def all(%AuthToken{} = auth, product_id, params \\ []),
+    do: REST.get(auth, "products/#{product_id}/images.json", params)
 
   @doc """
   Get a count of all product images.
@@ -25,8 +25,8 @@ defmodule ShopifyAPI.REST.ProductImage do
       iex> ShopifyApi.Rest.ProductImage.count(auth)
       {:ok, { "count" => integer }}
   """
-  def count(%AuthToken{} = auth, product_id),
-    do: REST.get(auth, "products/#{product_id}/images/count.json")
+  def count(%AuthToken{} = auth, product_id, params \\ []),
+    do: REST.get(auth, "products/#{product_id}/images/count.json", params)
 
   @doc """
   Get all images for a single product.
@@ -36,6 +36,7 @@ defmodule ShopifyAPI.REST.ProductImage do
       iex> ShopifyApi.Rest.ProductImage.get(auth, map)
       {:ok, { "image" => %{} }}
   """
+  @deprecated "Duplicate of all/2"
   def get(%AuthToken{} = auth, product_id),
     do: REST.get(auth, "products/#{product_id}/images.json")
 
@@ -47,8 +48,8 @@ defmodule ShopifyAPI.REST.ProductImage do
       iex> ShopifyApi.Rest.ProductImage.get(auth, map)
       {:ok, { "image" => %{} }}
   """
-  def get(%AuthToken{} = auth, product_id, image_id),
-    do: REST.get(auth, "products/#{product_id}/images/#{image_id}.json")
+  def get(%AuthToken{} = auth, product_id, image_id, params \\ []),
+    do: REST.get(auth, "products/#{product_id}/images/#{image_id}.json", params)
 
   @doc """
   Create a new product image.

--- a/lib/shopify_api/rest/recurring_application_charge.ex
+++ b/lib/shopify_api/rest/recurring_application_charge.ex
@@ -30,13 +30,13 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
       iex> ShopifyAPI.REST.RecurringApplicationCharge.get(auth, integer)
       {:ok, { "recurring_application_charge" => %{} }}
   """
-  def get(%AuthToken{} = auth, recurring_application_charge_id, params \\ []),
-    do:
-      REST.get(
-        auth,
-        "recurring_application_charges/#{recurring_application_charge_id}.json",
-        params
-      )
+  def get(%AuthToken{} = auth, recurring_application_charge_id, params \\ []) do
+    REST.get(
+      auth,
+      "recurring_application_charges/#{recurring_application_charge_id}.json",
+      params
+    )
+  end
 
   @doc """
   Get a list of all recurring application charges.

--- a/lib/shopify_api/rest/recurring_application_charge.ex
+++ b/lib/shopify_api/rest/recurring_application_charge.ex
@@ -30,8 +30,13 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
       iex> ShopifyAPI.REST.RecurringApplicationCharge.get(auth, integer)
       {:ok, { "recurring_application_charge" => %{} }}
   """
-  def get(%AuthToken{} = auth, recurring_application_charge_id),
-    do: REST.get(auth, "recurring_application_charges/#{recurring_application_charge_id}.json")
+  def get(%AuthToken{} = auth, recurring_application_charge_id, params \\ []),
+    do:
+      REST.get(
+        auth,
+        "recurring_application_charges/#{recurring_application_charge_id}.json",
+        params
+      )
 
   @doc """
   Get a list of all recurring application charges.
@@ -41,7 +46,8 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
       iex> ShopifyAPI.REST.RecurringApplicationCharge.all(auth)
       {:ok, { "recurring_application_charges" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "recurring_application_charges.json")
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "recurring_application_charges.json", params)
 
   @doc """
   Activates a recurring application charge.

--- a/lib/shopify_api/rest/refund.ex
+++ b/lib/shopify_api/rest/refund.ex
@@ -14,7 +14,8 @@ defmodule ShopifyAPI.REST.Refund do
       iex> ShopifyAPI.REST.Refund.all(auth, string)
       {:ok, { "refunds" => [] }}
   """
-  def all(%AuthToken{} = auth, order_id), do: REST.get(auth, "orders/#{order_id}/refunds.json")
+  def all(%AuthToken{} = auth, order_id, params \\ []),
+    do: REST.get(auth, "orders/#{order_id}/refunds.json", params)
 
   @doc """
   Get a specific refund.
@@ -24,8 +25,8 @@ defmodule ShopifyAPI.REST.Refund do
       iex> ShopifyAPI.REST.Refund.get(auth, string, string)
       {:ok, { "refund" => %{} }}
   """
-  def get(%AuthToken{} = auth, order_id, refund_id),
-    do: REST.get(auth, "orders/#{order_id}/refunds/#{refund_id}.json")
+  def get(%AuthToken{} = auth, order_id, refund_id, params \\ []),
+    do: REST.get(auth, "orders/#{order_id}/refunds/#{refund_id}.json", params)
 
   @doc """
   Calculate a refund.

--- a/lib/shopify_api/rest/report.ex
+++ b/lib/shopify_api/rest/report.ex
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.Report do
       iex> ShopifyAPI.REST.Report.all(auth)
       {:ok, { "reports" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "reports.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "reports.json", params)
 
   @doc """
   Return a single report.
@@ -24,7 +24,8 @@ defmodule ShopifyAPI.REST.Report do
       iex> ShopifyAPI.REST.Report.get(auth, integer)
       {:ok, { "report" => %{} }}
   """
-  def get(%AuthToken{} = auth, report_id), do: REST.get(auth, "reports/#{report_id}.json")
+  def get(%AuthToken{} = auth, report_id, params \\ []),
+    do: REST.get(auth, "reports/#{report_id}.json", params)
 
   @doc """
   Create a new report.

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -22,7 +22,7 @@ defmodule ShopifyAPI.REST.Request do
   ## Public Interface
 
   def perform(%AuthToken{} = token, method, path, body \\ "", params \\ []) do
-    url = add_params_to_url(url(token, path), params)
+    url = token |> url(path) |> add_params_to_url(params)
     headers = headers(token)
 
     response =
@@ -185,7 +185,12 @@ defmodule ShopifyAPI.REST.Request do
       iex> add_params_to_url("http://example.com/wat?q=1&s=4", %{q: 3, t: 2})
       "http://example.com/wat?q=3&s=4&t=2"
   """
-  @spec add_params_to_url(binary, list) :: binary
+  @spec add_params_to_url(binary, list | map) :: binary
+  defp add_params_to_url(url, params) when is_map(params) do
+    list_params = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)
+    add_params_to_url(url, list_params)
+  end
+
   defp add_params_to_url(url, params) do
     url
     |> URI.parse()

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -22,7 +22,7 @@ defmodule ShopifyAPI.REST.Request do
   ## Public Interface
 
   def perform(%AuthToken{} = token, method, path, body \\ "", params \\ []) do
-    url = url(token, path) |> add_params_to_url(params)
+    url = add_params_to_url(url(token, path), params)
     headers = headers(token)
 
     response =
@@ -197,13 +197,11 @@ defmodule ShopifyAPI.REST.Request do
   defp merge_uri_params(uri, []), do: uri
 
   defp merge_uri_params(%URI{query: nil} = uri, params) when is_list(params) or is_map(params) do
-    uri
-    |> Map.put(:query, URI.encode_query(params))
+    Map.put(uri, :query, URI.encode_query(params))
   end
 
   defp merge_uri_params(%URI{} = uri, params) when is_list(params) or is_map(params) do
-    uri
-    |> Map.update!(:query, fn q ->
+    Map.update!(uri, :query, fn q ->
       q
       |> URI.decode_query()
       |> Map.merge(param_list_to_map_with_string_keys(params))

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -163,28 +163,6 @@ defmodule ShopifyAPI.REST.Request do
          do: body
   end
 
-  @doc """
-  Take an existing URI and add additional params, appending and replacing as necessary
-  ## Examples
-      iex> add_params_to_url("http://example.com/wat", [])
-      "http://example.com/wat"
-      iex> add_params_to_url("http://example.com/wat", [q: 1])
-      "http://example.com/wat?q=1"
-      iex> add_params_to_url("http://example.com/wat", [q: 1, t: 2])
-      "http://example.com/wat?q=1&t=2"
-      iex> add_params_to_url("http://example.com/wat", %{q: 1, t: 2})
-      "http://example.com/wat?q=1&t=2"
-      iex> add_params_to_url("http://example.com/wat?q=1&t=2", [])
-      "http://example.com/wat?q=1&t=2"
-      iex> add_params_to_url("http://example.com/wat?q=1", [t: 2])
-      "http://example.com/wat?q=1&t=2"
-      iex> add_params_to_url("http://example.com/wat?q=1", [q: 3, t: 2])
-      "http://example.com/wat?q=3&t=2"
-      iex> add_params_to_url("http://example.com/wat?q=1&s=4", [q: 3, t: 2])
-      "http://example.com/wat?q=3&s=4&t=2"
-      iex> add_params_to_url("http://example.com/wat?q=1&s=4", %{q: 3, t: 2})
-      "http://example.com/wat?q=3&s=4&t=2"
-  """
   @spec add_params_to_url(binary, list | map) :: binary
   defp add_params_to_url(url, params) when is_map(params) do
     list_params = Enum.map(params, fn {key, value} -> {String.to_existing_atom(key), value} end)

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -186,11 +186,11 @@ defmodule ShopifyAPI.REST.Request do
       "http://example.com/wat?q=3&s=4&t=2"
   """
   @spec add_params_to_url(binary, list) :: binary
-  def add_params_to_url(url, params) do
+  defp add_params_to_url(url, params) do
     url
     |> URI.parse()
     |> merge_uri_params(params)
-    |> String.Chars.to_string()
+    |> to_string()
   end
 
   @spec merge_uri_params(URI.t(), list) :: URI.t()

--- a/lib/shopify_api/rest/shop.ex
+++ b/lib/shopify_api/rest/shop.ex
@@ -14,5 +14,5 @@ defmodule ShopifyAPI.REST.Shop do
       iex> ShopifyAPI.REST.Shop.get(auth)
       {:ok, { "shop" => %{} }}
   """
-  def get(%AuthToken{} = auth), do: REST.get(auth, "shop.json")
+  def get(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "shop.json", params)
 end

--- a/lib/shopify_api/rest/smart_collection.ex
+++ b/lib/shopify_api/rest/smart_collection.ex
@@ -13,7 +13,8 @@ defmodule ShopifyAPI.REST.SmartCollection do
       iex> ShopifyAPI.REST.SmartCollection.all(token)
       {:ok, %{ "smart_collections" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "admin/smart_collections.json")
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "admin/smart_collections.json", params)
 
   @doc """
   Get a count of all SmartCollections.
@@ -22,7 +23,8 @@ defmodule ShopifyAPI.REST.SmartCollection do
       iex> ShopifyAPI.REST.SmartCollection.count(token)
       {:ok, { "count": integer }}
   """
-  def count(%AuthToken{} = auth), do: REST.get(auth, "smart_collections/count.json")
+  def count(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "smart_collections/count.json", params)
 
   @doc """
   Return a single SmartCollection.
@@ -31,8 +33,8 @@ defmodule ShopifyAPI.REST.SmartCollection do
       iex> ShopifyAPI.REST.SmartCollection.get(auth, string)
       {:ok, %{ "smart_collection" => %{} }}
   """
-  def get(%AuthToken{} = auth, smart_collection_id),
-    do: REST.get(auth, "smart_collections/#{smart_collection_id}.json")
+  def get(%AuthToken{} = auth, smart_collection_id, params \\ []),
+    do: REST.get(auth, "smart_collections/#{smart_collection_id}.json", params)
 
   @doc """
   Create a SmartCollection.

--- a/lib/shopify_api/rest/tender_transaction.ex
+++ b/lib/shopify_api/rest/tender_transaction.ex
@@ -9,8 +9,8 @@ defmodule ShopifyAPI.REST.TenderTransaction do
   @doc """
     Return all the Tender Transactions.
   """
-  def all(%AuthToken{} = auth, params \\ %{}),
-    do: REST.get(auth, "tender_transactions.json?" <> URI.encode_query(params))
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "tender_transactions.json", params)
 
   def max_per_page, do: @shopify_per_page_max
 end

--- a/lib/shopify_api/rest/theme.ex
+++ b/lib/shopify_api/rest/theme.ex
@@ -14,8 +14,8 @@ defmodule ShopifyAPI.REST.Theme do
       iex> ShopifyAPI.REST.Theme.get(auth, integer)
       {:ok, { "theme" => %{} }}
   """
-  def get(%AuthToken{} = auth, theme_id, params \\ %{}),
-    do: REST.get(auth, "themes/#{theme_id}.json?" <> URI.encode_query(params))
+  def get(%AuthToken{} = auth, theme_id, params \\ []),
+    do: REST.get(auth, "themes/#{theme_id}.json", params)
 
   @doc """
   Return a list of all themes.
@@ -25,8 +25,8 @@ defmodule ShopifyAPI.REST.Theme do
       iex> ShopifyAPI.REST.Theme.all(auth)
       {:ok, { "themes" => [] }}
   """
-  def all(%AuthToken{} = auth, params \\ %{}),
-    do: REST.get(auth, "themes.json?" <> URI.encode_query(params))
+  def all(%AuthToken{} = auth, params \\ []),
+    do: REST.get(auth, "themes.json", params)
 
   @doc """
   Update a theme.

--- a/lib/shopify_api/rest/transaction.ex
+++ b/lib/shopify_api/rest/transaction.ex
@@ -7,8 +7,8 @@ defmodule ShopifyAPI.REST.Transaction do
   @doc """
     Return all the Transactions for an Order.
   """
-  def all(%AuthToken{} = auth, order_id),
-    do: REST.get(auth, "orders/#{order_id}/transactions.json")
+  def all(%AuthToken{} = auth, order_id, params \\ []),
+    do: REST.get(auth, "orders/#{order_id}/transactions.json", params)
 
   def create(%AuthToken{} = auth, %{transaction: %{order_id: order_id}} = transaction),
     do: REST.post(auth, "orders/#{order_id}/transactions.json", transaction)

--- a/lib/shopify_api/rest/usage_charge.ex
+++ b/lib/shopify_api/rest/usage_charge.ex
@@ -37,13 +37,15 @@ defmodule ShopifyAPI.REST.UsageCharge do
   def get(
         %AuthToken{} = auth,
         recurring_application_charge_id,
-        %{usage_charge: %{id: usage_charge_id}}
+        %{usage_charge: %{id: usage_charge_id}},
+        params \\ []
       ) do
     REST.get(
       auth,
       "recurring_application_charges/#{recurring_application_charge_id}/usage_charges/#{
         usage_charge_id
-      }.json"
+      }.json",
+      params
     )
   end
 
@@ -55,10 +57,11 @@ defmodule ShopifyAPI.REST.UsageCharge do
       iex> ShopifyAPI.REST.UsageCharge.all(auth, integer)
       {:ok, { "usage_charges" => [] }}
   """
-  def all(%AuthToken{} = auth, recurring_application_charge_id) do
+  def all(%AuthToken{} = auth, recurring_application_charge_id, params \\ []) do
     REST.get(
       auth,
-      "recurring_application_charge_id/#{recurring_application_charge_id}/usage_charges.json"
+      "recurring_application_charge_id/#{recurring_application_charge_id}/usage_charges.json",
+      params
     )
   end
 end

--- a/lib/shopify_api/rest/user.ex
+++ b/lib/shopify_api/rest/user.ex
@@ -14,7 +14,8 @@ defmodule ShopifyAPI.REST.User do
       iex> ShopifyAPI.REST.User.get(auth, integer)
       {:ok, { "user" => %{} }}
   """
-  def get(%AuthToken{} = auth, user_id), do: REST.get(auth, "users/#{user_id}.json")
+  def get(%AuthToken{} = auth, user_id, params \\ []),
+    do: REST.get(auth, "users/#{user_id}.json", params)
 
   @doc """
   Return a list of all users.
@@ -24,7 +25,7 @@ defmodule ShopifyAPI.REST.User do
       iex> ShopifyAPI.REST.User.all(auth)
       {:ok, { "users" => [] }}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "users.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "users.json", params)
 
   @doc """
   Get the currently logged-in user.
@@ -34,5 +35,5 @@ defmodule ShopifyAPI.REST.User do
       iex> ShopifyAPI.REST.User.current(auth)
       {:ok, { "user" => %{} }}
   """
-  def current(%AuthToken{} = auth), do: REST.get(auth, "users/current.json")
+  def current(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "users/current.json", params)
 end

--- a/lib/shopify_api/rest/variant.ex
+++ b/lib/shopify_api/rest/variant.ex
@@ -7,7 +7,8 @@ defmodule ShopifyAPI.REST.Variant do
   @doc """
     Return a single Product Variant
   """
-  def get(%AuthToken{} = auth, variant_id), do: REST.get(auth, "variants/#{variant_id}.json")
+  def get(%AuthToken{} = auth, variant_id, params \\ []),
+    do: REST.get(auth, "variants/#{variant_id}.json", params)
 
   @doc """
     Return all of a Product's Variants.
@@ -15,8 +16,8 @@ defmodule ShopifyAPI.REST.Variant do
     iex> ShopifyAPI.REST.Variant.get(auth, product_id)
 
   """
-  def all(%AuthToken{} = auth, product_id),
-    do: REST.get(auth, "products/#{product_id}/variants.json")
+  def all(%AuthToken{} = auth, product_id, params \\ []),
+    do: REST.get(auth, "products/#{product_id}/variants.json", params)
 
   @doc """
     Return a count of all Product Variants.
@@ -25,8 +26,8 @@ defmodule ShopifyAPI.REST.Variant do
   {:ok, %{"count" => integer}}
   """
 
-  def count(%AuthToken{} = auth, product_id),
-    do: REST.get(auth, "products/#{product_id}/variants/count.json")
+  def count(%AuthToken{} = auth, product_id, params \\ []),
+    do: REST.get(auth, "products/#{product_id}/variants/count.json", params)
 
   @doc """
     Delete a Product Variant.

--- a/lib/shopify_api/rest/webhook.ex
+++ b/lib/shopify_api/rest/webhook.ex
@@ -23,9 +23,10 @@ defmodule ShopifyAPI.REST.Webhook do
   iex> ShopifyAPI.REST.Webhook.all(auth)
   {:ok, %{"webhooks" => [%{"webhook_id" => "_", "address" => "https://example.com"}]}}
   """
-  def all(%AuthToken{} = auth), do: REST.get(auth, "webhooks.json")
+  def all(%AuthToken{} = auth, params \\ []), do: REST.get(auth, "webhooks.json", params)
 
-  def get(%AuthToken{} = auth, webhook_id), do: REST.get(auth, "webhooks/#{webhook_id}.json")
+  def get(%AuthToken{} = auth, webhook_id, params \\ []),
+    do: REST.get(auth, "webhooks/#{webhook_id}.json", params)
 
   def update(%AuthToken{} = auth, %{webhook: %{webhook_id: webhook_id}} = webhook),
     do: REST.put(auth, "webhooks/#{webhook_id}.json", webhook)


### PR DESCRIPTION
This PR is in support of the eventual changes required for Shopify's new pagination API. 

Currently, most of the endpoints that support query params handle encoding them at the entry point, i.e. the public layer. This PR refactors that functionality to a lower level (currently the `REST.Request` module) in an attempt to group related code in a more sensible location, as well as potentially removing some duplication.

A few questions/concerns I have from the outset:
1. The query param merging code (which I borrowed from tentacat) is very comprehensive, and it may be the case that we don't require that sort of complexity (it didn't exist in our repo previously, so safe to assume we were operating fine without it). Is that over-engineering?
2. Elixir convention is to use keyword lists as containers for optional parameters, however in most if not all places we are using maps. Does it make more sense to introduce potentially breaking changes by standardizing on the Elixir convention or to adjust a smaller amount of code to accommodate our current usage of maps as optional parameter vessels? See discussion here, especially Jose's answer: https://elixirforum.com/t/passing-in-options-maps-vs-keyword-lists/1963