### PR TITLE
Set pagination: :none for Customer.get/2

### DIFF
--- a/lib/shopify_api/rest/customer.ex
+++ b/lib/shopify_api/rest/customer.ex
@@ -26,8 +26,14 @@ defmodule ShopifyAPI.REST.Customer do
       iex> ShopifyAPI.REST.Customer.get(auth, integer)
       {:ok, %{} = customer}
   """
-  def get(%AuthToken{} = auth, customer_id, params \\ []),
-    do: REST.get(auth, "customers/#{customer_id}.json", params)
+  def get(%AuthToken{} = auth, customer_id, params \\ [], options \\ []) do
+    REST.get(
+      auth,
+      "customers/#{customer_id}.json",
+      params,
+      Keyword.merge([pagination: :none], options)
+    )
+  end
 
   @doc """
   Return a customers that match supplied query.


### PR DESCRIPTION
This one slipped the net in #258 -- I took a quick pass of other calls to `REST.get` and didn't identify anything else missing this.

Chose not to add a CHANGELOG entry, as this is a minor fixup for the previous PR.