### PR TITLE
Clean up CHANGELOG, add more explicit notice to breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## Unreleased
-- Removed `Exq` dependency, EventPipe.EventQueue & EventPipe.ModuleNameWorker & surrounding modules.
 
-## 0.8.0
+## 0.8.0 [unreleased]
 
-- Add ability to specify pagination options for GET resources, defaults to blocking until all results returned.
-- Removed top-level wrappers of Shopify REST response values.
-  WARNING This is a breaking change, return values that were
-  `{:ok, %{"orders" => [%{}, ...]}}` are now `{:ok, [%{}, ...]}`
+- BREAKING: Switch default version of REST API to 2020-01 (was 2019-04).
+- BREAKING: Add ability to specify pagination options for GET on collection resources, defaults to blocking until all results returned.
+- BREAKING: Removed top-level wrappers of Shopify REST response values.
+  + Return values that were `{:ok, %{"orders" => [%{}, ...]}}` are now `{:ok, [%{}, ...]}`
+- BREAKING: Removed `Exq` dependency, EventPipe.EventQueue & EventPipe.ModuleNameWorker & surrounding modules.
 
 ## 0.7.2
 


### PR DESCRIPTION
Just a little housekeeping before we start packing up a new release.