### PR TITLE
Bump version to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.8.0 [unreleased]
+## 0.8.0
 
 - BREAKING: Switch default version of REST API to 2020-01 (was 2019-04).
 - BREAKING: Add ability to specify pagination options for GET on collection resources, defaults to blocking until all results returned.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.7.2"
+  @version "0.8.0"
 
   def project do
     [


### PR DESCRIPTION
New release includes:

- BREAKING: Switch default version of REST API to 2020-01 (was 2019-04).
- BREAKING: Add ability to specify pagination options for GET on collection resources, defaults to blocking until all results returned.
- BREAKING: Removed top-level wrappers of Shopify REST response values.
  + Return values that were `{:ok, %{"orders" => [%{}, ...]}}` are now `{:ok, [%{}, ...]}`
- BREAKING: Removed `Exq` dependency, EventPipe.EventQueue & EventPipe.ModuleNameWorker & surrounding modules.