### PR TITLE
Bump version to v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.8.1
+
 - Fix: Remove call to `String.to_existing_atom` from param serialization. This could previously result in an unexpected error from the caller.
 
 ## 0.8.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.2.5"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.8.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.8.1"
 
   def project do
     [


### PR DESCRIPTION
This includes the fix removing a `String.to_existing_atom/1` in parameter serialization.