### PR TITLE
GraphQL Throttling

### DIFF
--- a/lib/shopify_api.ex
+++ b/lib/shopify_api.ex
@@ -2,6 +2,11 @@ defmodule ShopifyAPI do
   alias ShopifyAPI.RateLimiting
   alias ShopifyAPI.Throttled
 
+  @spec graphql_request(ShopifyAPI.AuthToken.t(), function(), integer()) ::
+          ShopifyAPI.GraphQL.query_response()
+  def graphql_request(token, func, estimated_cost),
+    do: Throttled.graphql_request(func, token, estimated_cost)
+
   def request(token, func), do: Throttled.request(func, token, RateLimiting.RESTTracker)
 
   @doc false

--- a/lib/shopify_api.ex
+++ b/lib/shopify_api.ex
@@ -2,10 +2,12 @@ defmodule ShopifyAPI do
   alias ShopifyAPI.RateLimiting
   alias ShopifyAPI.Throttled
 
-  @spec graphql_request(ShopifyAPI.AuthToken.t(), function(), integer()) ::
+  @spec graphql_request(ShopifyAPI.AuthToken.t(), String.t(), integer(), map(), list()) ::
           ShopifyAPI.GraphQL.query_response()
-  def graphql_request(token, func, estimated_cost),
-    do: Throttled.graphql_request(func, token, estimated_cost)
+  def graphql_request(token, query, estimated_cost, variables \\ %{}, opts \\ []) do
+    func = fn -> ShopifyAPI.GraphQL.query(token, query, variables, opts) end
+    Throttled.graphql_request(func, token, estimated_cost)
+  end
 
   def request(token, func), do: Throttled.request(func, token, RateLimiting.RESTTracker)
 

--- a/lib/shopify_api.ex
+++ b/lib/shopify_api.ex
@@ -2,6 +2,18 @@ defmodule ShopifyAPI do
   alias ShopifyAPI.RateLimiting
   alias ShopifyAPI.Throttled
 
+  @doc """
+  A helper function for making throttled GraphQL requests.
+
+  ## Example:
+
+      iex> query = "mutation metafieldDelete($input: MetafieldDeleteInput!){ metafieldDelete(input: $input) {deletedId userErrors {field message }}}",
+      iex> estimated_cost = 10
+      iex> variables = %{input: %{id: "gid://shopify/Metafield/9208558682200"}}
+      iex> options = [debug: true]
+      iex> ShopifyAPI.graphql_request(auth_token, query, estimated_cost, variables, options)
+      {:ok, %ShopifyAPI.GraphQL.Response{...}}
+  """
   @spec graphql_request(ShopifyAPI.AuthToken.t(), String.t(), integer(), map(), list()) ::
           ShopifyAPI.GraphQL.query_response()
   def graphql_request(token, query, estimated_cost, variables \\ %{}, opts \\ []) do

--- a/lib/shopify_api/application.ex
+++ b/lib/shopify_api/application.ex
@@ -7,6 +7,7 @@ defmodule ShopifyAPI.Application do
   # for more information on OTP Applications
   def start(_type, _args) do
     RateLimiting.RESTTracker.init()
+    RateLimiting.GraphQLTracker.init()
 
     # Define workers and child supervisors to be supervised
     children = []

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -6,12 +6,16 @@ defmodule ShopifyAPI.GraphQL do
   require Logger
 
   alias ShopifyAPI.AuthToken
-  alias ShopifyAPI.GraphQL.{Response, Telemetry}
+  alias ShopifyAPI.GraphQL.{JSONParseError, Response, Telemetry}
   alias ShopifyAPI.JSONSerializer
 
   @default_graphql_version "2019-07"
 
   @log_module __MODULE__ |> to_string() |> String.trim_leading("Elixir.")
+
+  @type query_response ::
+          {:ok, Response.t()}
+          | {:error, JSONParseError.t() | HTTPoison.Response.t() | HTTPoison.Error.t()}
 
   @doc """
     Makes requests against Shopify GraphQL and returns a tuple containing
@@ -24,6 +28,7 @@ defmodule ShopifyAPI.GraphQL do
       iex> ShopifyAPI.GraphQL.query(auth, query, variables)
       {:ok, %Response{...}}
   """
+  @spec query(AuthToken.t(), String.t(), map(), list()) :: query_response()
   def query(%AuthToken{} = auth, query_string, variables \\ %{}, opts \\ []) do
     url = build_url(auth, opts)
     headers = build_headers(auth, opts)

--- a/lib/shopify_api/rate_limiting/graphql.ex
+++ b/lib/shopify_api/rate_limiting/graphql.ex
@@ -1,0 +1,17 @@
+defmodule ShopifyAPI.RateLimiting.GraphQL do
+  @plus_bucket 2000
+  @nonplus_bucket 1000
+
+  @plus_restore_rate 100
+  @nonplus_restore_rate 50
+
+  @max_query_cost 1000
+
+  def request_bucket(%{plus: true}), do: @plus_bucket
+  def request_bucket(%{plus: false}), do: @nonplus_bucket
+
+  def restore_rate_per_second(%{plus: true}), do: @plus_restore_rate
+  def restore_rate_per_second(%{plus: false}), do: @nonplus_restore_rate
+
+  def max_query_cost, do: @max_query_cost
+end

--- a/lib/shopify_api/rate_limiting/graphql_call_limits.ex
+++ b/lib/shopify_api/rate_limiting/graphql_call_limits.ex
@@ -2,6 +2,8 @@ defmodule ShopifyAPI.RateLimiting.GraphQLCallLimits do
   alias ShopifyAPI.GraphQL
   alias ShopifyAPI.RateLimiting
 
+  # Our internal point availability tracking sometimes differs from Shopify's
+  # Adding this padding prevents requests being throttled unecessarily
   @estimate_padding 20
 
   @spec calculate_wait(

--- a/lib/shopify_api/rate_limiting/graphql_call_limits.ex
+++ b/lib/shopify_api/rate_limiting/graphql_call_limits.ex
@@ -1,0 +1,48 @@
+defmodule ShopifyAPI.RateLimiting.GraphQLCallLimits do
+  alias ShopifyAPI.GraphQL
+  alias ShopifyAPI.RateLimiting
+
+  @estimate_padding 20
+
+  @spec calculate_wait(
+          {String.t(), integer(), DateTime.t()},
+          ShopifyAPI.AuthToken.t(),
+          integer(),
+          DateTime.t()
+        ) :: integer()
+  def calculate_wait(
+        {_key, points_available, time},
+        token,
+        estimated_cost,
+        now \\ DateTime.utc_now()
+      ) do
+    seconds_elapsed = DateTime.diff(now, time)
+    restore_rate_per_second = RateLimiting.GraphQL.restore_rate_per_second(token)
+    estimated_restore_amount = restore_rate_per_second * seconds_elapsed
+
+    diff = points_available + estimated_restore_amount - estimated_cost - @estimate_padding
+
+    case diff > 0 do
+      true -> 0
+      false -> round(abs(diff) / restore_rate_per_second * 1000)
+    end
+  end
+
+  @spec get_api_remaining_points(GraphQL.Response.t() | HTTPoison.Response.t()) :: integer()
+  def get_api_remaining_points(%{
+        metadata: %{"cost" => %{"throttleStatus" => %{"currentlyAvailable" => available}}}
+      }) do
+    available
+  end
+
+  # throttled queries return the HTTPoison.Response object
+  def get_api_remaining_points(%{
+        body: %{
+          "extensions" => %{"cost" => %{"throttleStatus" => %{"currentlyAvailable" => available}}}
+        }
+      }) do
+    available
+  end
+
+  def estimate_padding, do: @estimate_padding
+end

--- a/lib/shopify_api/rate_limiting/graphql_tracker.ex
+++ b/lib/shopify_api/rate_limiting/graphql_tracker.ex
@@ -1,0 +1,61 @@
+defmodule ShopifyAPI.RateLimiting.GraphQLTracker do
+  @moduledoc """
+  Handles Tracking of GraphQL API throttling and when the API will be available for a request.
+  """
+
+  alias ShopifyAPI.AuthToken
+  alias ShopifyAPI.RateLimiting
+
+  @behaviour RateLimiting.Tracker
+
+  @name :shopify_api_graphql_availability_tracker
+
+  @impl RateLimiting.Tracker
+  def init, do: :ets.new(@name, [:named_table, :public])
+
+  @impl RateLimiting.Tracker
+  def all, do: :ets.tab2list(@name)
+
+  def clear_all, do: :ets.delete_all_objects(@name)
+
+  @impl RateLimiting.Tracker
+  def api_hit_limit(%AuthToken{} = token, http_response, _now \\ DateTime.utc_now()) do
+    update_api_call_limit(token, http_response)
+  end
+
+  @impl RateLimiting.Tracker
+  def update_api_call_limit(%AuthToken{} = token, http_response) do
+    remaining = RateLimiting.GraphQLCallLimits.get_api_remaining_points(http_response)
+
+    set(token, remaining, 0)
+  end
+
+  @impl RateLimiting.Tracker
+  def get(%ShopifyAPI.AuthToken{} = token, now \\ DateTime.utc_now(), estimated_cost) do
+    case :ets.lookup(@name, ShopifyAPI.AuthToken.create_key(token)) do
+      [] ->
+        {RateLimiting.GraphQL.request_bucket(token), 0}
+
+      [{_key, points_available, _time} | _] when points_available > estimated_cost ->
+        {points_available, 0}
+
+      [{_key, points_available, _time} = value | _] ->
+        wait_in_milliseconds =
+          RateLimiting.GraphQLCallLimits.calculate_wait(value, token, estimated_cost, now)
+
+        {points_available, wait_in_milliseconds}
+    end
+  end
+
+  @impl RateLimiting.Tracker
+  def set(token, points_available, _, now \\ DateTime.utc_now())
+
+  # Do nothing
+  def set(_token, nil, _, _now), do: {0, 0}
+
+  # Sets the current points available and time of the transaction (now)
+  def set(%ShopifyAPI.AuthToken{} = token, points_available, _, now) do
+    :ets.insert(@name, {ShopifyAPI.AuthToken.create_key(token), points_available, now})
+    {points_available, 0}
+  end
+end

--- a/lib/shopify_api/rate_limiting/rest_tracker.ex
+++ b/lib/shopify_api/rate_limiting/rest_tracker.ex
@@ -37,12 +37,12 @@ defmodule ShopifyAPI.RateLimiting.RESTTracker do
   end
 
   @impl RateLimiting.Tracker
-  def get(%ShopifyAPI.AuthToken{} = token, now \\ DateTime.utc_now()) do
+  def get(%ShopifyAPI.AuthToken{} = token, now \\ DateTime.utc_now(), _estimated_cost) do
     case :ets.lookup(@name, ShopifyAPI.AuthToken.create_key(token)) do
       [] ->
         {RateLimiting.REST.request_bucket(token), 0}
 
-      [{_token, count, time} | _] ->
+      [{_key, count, time} | _] ->
         diff = time |> DateTime.diff(now, :millisecond) |> max(0)
 
         {count, diff}

--- a/lib/shopify_api/rate_limiting/tracker.ex
+++ b/lib/shopify_api/rate_limiting/tracker.ex
@@ -9,6 +9,6 @@ defmodule ShopifyAPI.RateLimiting.Tracker do
   @callback all :: list()
   @callback api_hit_limit(AuthToken.t(), HTTPoison.Response.t(), DateTime.t()) :: t()
   @callback update_api_call_limit(AuthToken.t(), HTTPoison.Response.t()) :: t()
-  @callback get(AuthToken.t(), DateTime.t()) :: t()
+  @callback get(AuthToken.t(), DateTime.t(), integer()) :: t()
   @callback set(AuthToken.t(), available_count(), availability_delay(), DateTime.t()) :: t()
 end

--- a/lib/shopify_api/throttled.ex
+++ b/lib/shopify_api/throttled.ex
@@ -7,16 +7,18 @@ defmodule ShopifyAPI.Throttled do
 
   Request "buckets" are identified based on the provided `AuthToken`. An ets
   table is checked before making a request, seeing if additional requests are
-  allowed. If not, the client will sleep before attempting the request.
+  allowed. If not, the client will sleep before attempting the request. GraphQL
+  requests pass an estimated query cost, and this estimated cost is used to
+  calculate precise sleep times.
 
-  Upon receiving a HTTP response, the number of allowed requests is
-  extracted from response headers and inserted into the ets table.
+  Upon receiving a HTTP response, the number of allowed requests is extracted
+  (from response headers for REST/response body for GraphQL), and inserted into
+  the ets table.
 
-  If Shopify returns the `429 Too Many Requests` status code for a request, it
-  will be retried after a delay and re-check of the ets table, to a maximum of
-  10 total attempts (this is configurable).
-
-  See docs: https://help.shopify.com/en/api/reference/rest-admin-api-rate-limits
+  If Shopify throttles the request (returns the `429 Too Many Requests` status
+  code for a REST request, or a "Throttled" error for a GraphQL request), the
+  request will be retried after a delay and re-check of the ets table, to a
+  maximum of 10 total attempts (this is configurable).
   """
   require Logger
 

--- a/lib/shopify_api/throttled.ex
+++ b/lib/shopify_api/throttled.ex
@@ -24,17 +24,26 @@ defmodule ShopifyAPI.Throttled do
 
   @request_max_tries 10
 
-  def request(func, token, max_tries \\ @request_max_tries, depth \\ 1, tracker_impl)
 
-  def request(func, _token, max_tries, depth, _tracker_impl)
+  def request(
+        func,
+        token,
+        max_tries \\ @request_max_tries,
+        depth \\ 1,
+        estimated_cost \\ 1,
+        tracker_impl
+      )
+
+  def request(func, _token, max_tries, depth, _estimated_cost, _tracker_impl)
       when is_function(func) and max_tries == depth,
       do: func.()
 
-  def request(func, token, max_tries, depth, tracker_impl) when is_function(func) do
+  def request(func, token, max_tries, depth, estimated_cost, tracker_impl)
+      when is_function(func) do
     over_limit_status_code = RateLimiting.REST.over_limit_status_code()
 
     token
-    |> tracker_impl.get()
+    |> tracker_impl.get(estimated_cost)
     |> make_request(func)
     |> case do
       # over REST request limit, back off and try again.

--- a/lib/shopify_api/throttled.ex
+++ b/lib/shopify_api/throttled.ex
@@ -24,6 +24,14 @@ defmodule ShopifyAPI.Throttled do
 
   @request_max_tries 10
 
+  def graphql_request(func, token, estimated_cost, depth \\ 1, max_tries \\ @request_max_tries) do
+    max_query_cost = RateLimiting.GraphQL.max_query_cost()
+
+    case estimated_cost <= max_query_cost do
+      true -> request(func, token, max_tries, depth, estimated_cost, RateLimiting.GraphQLTracker)
+      false -> {:error, "Query costs cannot exceed #{max_query_cost} points"}
+    end
+  end
 
   def request(
         func,

--- a/test/shopify_api/rate_limiting/graphql_call_limits_test.exs
+++ b/test/shopify_api/rate_limiting/graphql_call_limits_test.exs
@@ -1,0 +1,62 @@
+defmodule ShopifyAPI.RateLimiting.GraphQLCallLimitsTest do
+  use ExUnit.Case
+  use ExUnitProperties
+
+  alias ShopifyAPI.RateLimiting.GraphQLCallLimits
+
+  setup do
+    token = %ShopifyAPI.AuthToken{}
+    now = ~U[2020-01-01 12:00:00.000000Z]
+    %{now: now, token: token}
+  end
+
+  describe "calculate_wait/3" do
+    property "larger points available than cost", %{now: now, token: token} do
+      check all(
+              int1 <- positive_integer(),
+              int2 <- positive_integer(),
+              estimated_cost = int1,
+              points_available = int1 + int2,
+              points_available > estimated_cost
+            ) do
+        assert GraphQLCallLimits.calculate_wait(
+                 {"key", points_available + GraphQLCallLimits.estimate_padding(), now},
+                 token,
+                 estimated_cost,
+                 now
+               ) == 0
+      end
+    end
+
+    property "larger cost than points available", %{now: now, token: token} do
+      check all(
+              int1 <- positive_integer(),
+              int2 <- positive_integer(),
+              points_available = int1,
+              estimated_cost = int1 + int2,
+              estimated_cost > points_available
+            ) do
+        assert GraphQLCallLimits.calculate_wait(
+                 {"key", points_available, now},
+                 token,
+                 estimated_cost,
+                 now
+               ) > 0
+      end
+    end
+
+    property "enough elapsed time to refill the bucket", %{now: now, token: token} do
+      check all(
+              int <- positive_integer(),
+              date = DateTime.add(now, -int * 60 * 60)
+            ) do
+        assert GraphQLCallLimits.calculate_wait(
+                 {"key", 0, date},
+                 token,
+                 500,
+                 now
+               ) == 0
+      end
+    end
+  end
+end

--- a/test/shopify_api/rate_limiting/graphql_tracker_test.exs
+++ b/test/shopify_api/rate_limiting/graphql_tracker_test.exs
@@ -1,0 +1,56 @@
+defmodule ShopifyAPI.RateLimiting.GraphQLTrackerTest do
+  use ExUnit.Case
+
+  alias ShopifyAPI.RateLimiting.{GraphQL, GraphQLTracker}
+
+  setup do
+    GraphQLTracker.clear_all()
+    token = %ShopifyAPI.AuthToken{}
+    now = ~U[2020-01-01 12:00:00.000000Z]
+
+    %{now: now, token: token}
+  end
+
+  describe "update_api_call_limit" do
+    test "returns available from GraphQL.Response", %{token: token} do
+      available = 250
+
+      response = %ShopifyAPI.GraphQL.Response{
+        metadata: %{"cost" => %{"throttleStatus" => %{"currentlyAvailable" => available}}}
+      }
+
+      assert {^available, 0} = GraphQLTracker.update_api_call_limit(token, response)
+    end
+
+    test "returns available from HTTPoison.Response", %{token: token} do
+      available = 250
+
+      response = %HTTPoison.Response{
+        body: %{
+          "extensions" => %{"cost" => %{"throttleStatus" => %{"currentlyAvailable" => available}}}
+        }
+      }
+
+      assert {^available, 0} = GraphQLTracker.update_api_call_limit(token, response)
+    end
+  end
+
+  describe "get/3" do
+    test "handles get without having set", %{now: now, token: token} do
+      default = GraphQL.request_bucket(token)
+      assert {^default, 0} = GraphQLTracker.get(token, now, 1)
+    end
+
+    test "returns set points available", %{now: now, token: token} do
+      points = 500
+      GraphQLTracker.set(token, points, now)
+      assert {^points, 0} = GraphQLTracker.get(token, now, 1)
+    end
+
+    test "returns a wait when estimate exceeds available points", %{now: now, token: token} do
+      GraphQLTracker.set(token, 500, now)
+      {_, wait} = GraphQLTracker.get(token, now, 600)
+      assert wait > 0
+    end
+  end
+end

--- a/test/shopify_api/rate_limiting/rest_tracker_test.exs
+++ b/test/shopify_api/rate_limiting/rest_tracker_test.exs
@@ -42,7 +42,7 @@ defmodule ShopifyAPI.RateLimiting.RESTTrackerTest do
       now = ~U[2020-01-01 12:00:00.000000Z]
       token = %AuthToken{app_name: "empty", shop_name: "empty"}
 
-      assert {40, 0} == RESTTracker.get(token, now)
+      assert {40, 0} == RESTTracker.get(token, now, 1)
     end
 
     test "returns with a sleep after hitting limit" do
@@ -55,15 +55,15 @@ defmodule ShopifyAPI.RateLimiting.RESTTrackerTest do
 
       assert {0, 2000} == RESTTracker.api_hit_limit(token, response, hit_time)
 
-      assert {0, 2000} == RESTTracker.get(token, hit_time)
+      assert {0, 2000} == RESTTracker.get(token, hit_time, 1)
 
       wait_a_second = ~U[2020-01-01 12:00:01.100000Z]
 
-      assert {0, 900} == RESTTracker.get(token, wait_a_second)
+      assert {0, 900} == RESTTracker.get(token, wait_a_second, 1)
 
       wait_two_seconds = ~U[2020-01-01 12:00:02.100000Z]
 
-      assert {0, 0} == RESTTracker.get(token, wait_two_seconds)
+      assert {0, 0} == RESTTracker.get(token, wait_two_seconds, 1)
     end
   end
 end

--- a/test/shopify_api/throttled_test.exs
+++ b/test/shopify_api/throttled_test.exs
@@ -14,6 +14,53 @@ defmodule Test.ShopifyAPI.ThrottledTest do
   def func, do: send(self(), :func_called)
   def sleep_impl(_), do: send(self(), :sleep_called)
 
+  defmodule TrackerMock do
+    def get(_, _), do: {100, 0}
+    def api_hit_limit(_, _), do: {100, 0}
+
+    def update_api_call_limit(_, _) do
+      send(self(), :update_api_call_limit_called)
+      {100, 0}
+    end
+  end
+
+  describe "request/6" do
+    test "recurses when func returns over limit status code" do
+      func = fn ->
+        send(self(), :func_called)
+        {:ok, %{status_code: RateLimiting.REST.over_limit_status_code()}}
+      end
+
+      max_tries = 2
+      Throttled.request(func, @token, max_tries, TrackerMock)
+      for _ <- 1..max_tries, do: assert_received(:func_called)
+    end
+
+    test "recurses when func returns graphql throttled response" do
+      func = fn ->
+        send(self(), :func_called)
+        {:error, %{body: %{"errors" => [%{"message" => "Throttled"}]}, status_code: 200}}
+      end
+
+      max_tries = 2
+      Throttled.request(func, @token, max_tries, TrackerMock)
+      for _ <- 1..max_tries, do: assert_received(:func_called)
+    end
+
+    test "updates api call limit and does not recurse when func returns success" do
+      func = fn ->
+        send(self(), :func_called)
+        {:ok, %{status_code: 200}}
+      end
+
+      Throttled.request(func, @token, TrackerMock)
+
+      assert_receive :update_api_call_limit_called
+      assert_receive :func_called
+      refute_receive :func_called
+    end
+  end
+
   describe "make_request/3" do
     test "if limit has room call right away" do
       Throttled.make_request({1, 0}, &func/0, &sleep_impl/1)


### PR DESCRIPTION
This implements rate limiting for GraphQL requests. It adopts the `RateLimiting.Tracker` behaviour in a GraphQL tracker.

It functions similarly to the existing REST throttling, except:
- an estimated query cost must be passed to the `Throttled.graphql_request`
- that estimated cost is used to determine whether the request can proceed, `sleep`ing when necessary.