### PR TITLE
Chore/ch67325/bulk queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Add throttling for GraphQL.
+- Add GraphQL bulk fetch query method.
+- Switch default version of GraphQL API to 2019-10 (was 2019-07).
+
 ## 0.8.1
 
 - Fix: Remove call to `String.to_existing_atom` from param serialization. This could previously result in an unexpected error from the caller.

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -9,7 +9,7 @@ defmodule ShopifyAPI.GraphQL do
   alias ShopifyAPI.GraphQL.{JSONParseError, Response, Telemetry}
   alias ShopifyAPI.JSONSerializer
 
-  @default_graphql_version "2019-07"
+  @default_graphql_version "2019-10"
 
   @log_module __MODULE__ |> to_string() |> String.trim_leading("Elixir.")
 

--- a/lib/shopify_api/graphql/bulk_fetch.ex
+++ b/lib/shopify_api/graphql/bulk_fetch.ex
@@ -1,0 +1,82 @@
+defmodule ShopifyAPI.GraphQL.BulkFetch do
+  alias ShopifyAPI.AuthToken
+
+  @spec process(AuthToken.t(), String.t(), integer()) :: any()
+  def process(%AuthToken{} = token, query, polling_rate \\ 100) do
+    with :ok <- create(token, query),
+         {:ok, url} <- poll_till_completed(token, polling_rate),
+         {:ok, %{body: jsonl}} <- HTTPoison.get(url) do
+      {:ok, parse_bulk_response(jsonl)}
+    else
+      error -> error
+    end
+  end
+
+  defp create(token, query) do
+    query_string = Jason.encode!(query)
+
+    bulk_query = """
+    mutation {
+      bulkOperationRunQuery(
+        query: #{query_string}
+      ) {
+        bulkOperation {
+          id
+          status
+        }
+        userErrors {
+          field
+          message
+        }
+      }
+    }
+    """
+
+    resp = ShopifyAPI.graphql_request(token, bulk_query, 10)
+    errors = get_in(resp, [:response, "bulkOperationRunQuery", "userErrors"])
+
+    case Enum.empty?(errors) do
+      true -> :ok
+      false -> {:error, "Bulk Operation already in progress"}
+    end
+  end
+
+  defp poll_till_completed(token, polling_rate) do
+    Process.sleep(polling_rate)
+
+    {:ok, %{response: %{"currentBulkOperation" => %{"status" => status} = response}}} =
+      poll(token)
+
+    case status do
+      "COMPLETED" -> {:ok, Map.get(response, "url")}
+      _ -> poll_till_completed(token, polling_rate)
+    end
+  end
+
+  defp poll(%AuthToken{} = token) do
+    poll_query = """
+    {
+      currentBulkOperation {
+        id
+        status
+        errorCode
+        createdAt
+        completedAt
+        objectCount
+        fileSize
+        url
+        partialDataUrl
+      }
+    }
+    """
+
+    ShopifyAPI.graphql_request(token, poll_query, 1)
+  end
+
+  defp parse_bulk_response(jsonl) do
+    jsonl
+    |> String.split("\n")
+    |> Enum.drop(-1)
+    |> Enum.map(&Jason.decode!/1)
+  end
+end

--- a/lib/shopify_api/graphql/bulk_fetch.ex
+++ b/lib/shopify_api/graphql/bulk_fetch.ex
@@ -46,16 +46,12 @@ defmodule ShopifyAPI.GraphQL.BulkFetch do
       \"""
       iex> {:ok, token} = YourShopifyApp.ShopifyAPI.Shop.get_auth_token_from_slug("slug")
       iex> ShopifyAPI.GraphQL.BulkFetch.process!(token, query)
-      {:ok,
-        [%{"collection_id" => "gid://shopify/Collection/xxx", ...}],
-      }
+      [%{"collection_id" => "gid://shopify/Collection/xxx", ...}]
   """
-  @spec process!(AuthToken.t(), String.t(), integer()) :: {:ok, list()} | {:error, any()}
+  @spec process!(AuthToken.t(), String.t(), integer()) :: list()
   def process!(%AuthToken{} = token, query, polling_rate \\ 100) do
-    case fetch_jsonl(token, query, polling_rate) do
-      {:ok, jsonl} -> {:ok, parse_bulk_response!(jsonl)}
-      {:error, _} = error -> error
-    end
+    {:ok, jsonl} = fetch_jsonl(token, query, polling_rate)
+    parse_bulk_response!(jsonl)
   end
 
   @doc """

--- a/lib/shopify_api/graphql/bulk_fetch.ex
+++ b/lib/shopify_api/graphql/bulk_fetch.ex
@@ -1,21 +1,154 @@
 defmodule ShopifyAPI.GraphQL.BulkFetch do
   alias ShopifyAPI.AuthToken
 
-  @spec process(AuthToken.t(), String.t(), integer()) :: any()
-  def process(%AuthToken{} = token, query, polling_rate \\ 100) do
-    with :ok <- create(token, query),
-         {:ok, url} <- poll_till_completed(token, polling_rate),
+  @max_poll_count 100
+  @polling_timeout_message "BulkFetch timed out before completion"
+  @polling_query """
+  {
+    currentBulkOperation {
+      id
+      status
+      errorCode
+      createdAt
+      completedAt
+      objectCount
+      fileSize
+      url
+      partialDataUrl
+    }
+  }
+  """
+
+  @doc """
+  ## Example
+      iex> prod_id = 10
+      iex> query = \"""
+        {
+          product(id: "gid://shopify/Product/\#{prod_id}") {
+            collections(first: 1) {
+              edges {
+                node {
+                  collection_id: id
+                  }
+                }
+              }
+            metafields(first: 1) {
+              edges {
+                node {
+                  key
+                  value
+                  metafield_id: id
+                }
+              }
+            }
+          }
+        }
+      \"""
+      iex> {:ok, token} = YourShopifyApp.ShopifyAPI.Shop.get_auth_token_from_slug("slug")
+      iex> ShopifyAPI.GraphQL.BulkFetch.process!(token, query)
+      {:ok,
+        [%{"collection_id" => "gid://shopify/Collection/xxx", ...}],
+      }
+  """
+  @spec process!(AuthToken.t(), String.t(), integer()) :: {:ok, list()} | {:error, any()}
+  def process!(%AuthToken{} = token, query, polling_rate \\ 100) do
+    case fetch_jsonl(token, query, polling_rate) do
+      {:ok, jsonl} -> {:ok, parse_bulk_response!(jsonl)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Like process/3 but returns a Streamable collection of decoded JSON or errors.
+
+    ## Example
+      iex> prod_id = 10
+      iex> query = \"""
+        {
+          product(id: "gid://shopify/Product/\#{prod_id}") {
+            collections(first: 1) {
+              edges {
+                node {
+                  collection_id: id
+                  }
+                }
+              }
+            metafields(first: 1) {
+              edges {
+                node {
+                  key
+                  value
+                  metafield_id: id
+                }
+              }
+            }
+          }
+        }
+      \"""
+      iex> {:ok, token} = YourShopifyApp.ShopifyAPI.Shop.get_auth_token_from_slug("slug")
+      iex> func = fn {:ok, json} -> IO.puts(json) end # Warning we are not handling error conditions here.
+      iex> ShopifyAPI.GraphQL.BulkFetch.process_stream(token, query, func)
+  """
+  @spec process_stream(AuthToken.t(), String.t(), integer()) :: Enumerable.t()
+  def process_stream(%AuthToken{} = token, query, polling_rate \\ 100) do
+    case fetch_jsonl(token, query, polling_rate) do
+      {:ok, jsonl} ->
+        jsonl
+        |> String.splitter("\n", trim: true)
+        |> Stream.map(&ShopifyAPI.JSONSerializer.decode/1)
+
+      {:error, _} = error ->
+        [error]
+    end
+  end
+
+  @spec cancel(AuthToken.t(), String.t()) :: {:ok | :error, any()}
+  def cancel(token, bulk_query_id) do
+    query = """
+    mutation {
+      bulkOperationCancel(id: "#{bulk_query_id}") {
+        bulkOperation {
+          status
+        }
+        userErrors {
+          field
+          message
+        }
+      }
+    }
+    """
+
+    ShopifyAPI.graphql_request(token, query, 1)
+  end
+
+  @doc false
+  @spec fetch_jsonl(AuthToken.t(), String.t(), integer()) :: {:ok, String.t()} | {:error, any()}
+  def fetch_jsonl(%AuthToken{} = token, query, polling_rate) do
+    with bulk_query <- bulk_query_string(query),
+         {:ok, resp} <- ShopifyAPI.graphql_request(token, bulk_query, 10),
+         :ok <- handle_errors(resp),
+         bulk_query_id <- get_in(resp.response, ["bulkOperationRunQuery", "bulkOperation", "id"]),
+         {:ok, url} <- poll_till_completed(token, bulk_query_id, polling_rate),
          {:ok, %{body: jsonl}} <- HTTPoison.get(url) do
-      {:ok, parse_bulk_response(jsonl)}
+      {:ok, jsonl}
     else
       error -> error
     end
   end
 
-  defp create(token, query) do
-    query_string = Jason.encode!(query)
+  defp handle_errors(resp) do
+    errors = get_in(resp.response, ["bulkOperationRunQuery", "userErrors"])
 
-    bulk_query = """
+    case Enum.empty?(errors) do
+      true -> :ok
+      false -> {:error, fetch_first_error(errors)}
+    end
+  end
+
+  defp bulk_query_string(query) do
+    query_string = ShopifyAPI.JSONSerializer.encode!(query)
+
+    """
     mutation {
       bulkOperationRunQuery(
         query: #{query_string}
@@ -31,52 +164,38 @@ defmodule ShopifyAPI.GraphQL.BulkFetch do
       }
     }
     """
-
-    resp = ShopifyAPI.graphql_request(token, bulk_query, 10)
-    errors = get_in(resp, [:response, "bulkOperationRunQuery", "userErrors"])
-
-    case Enum.empty?(errors) do
-      true -> :ok
-      false -> {:error, "Bulk Operation already in progress"}
-    end
   end
 
-  defp poll_till_completed(token, polling_rate) do
+  defp fetch_first_error(errors) do
+    errors
+    |> List.first()
+    |> Map.get("message")
+  end
+
+  defp poll_till_completed(token, bulk_query_id, polling_rate, depth \\ 0)
+
+  defp poll_till_completed(token, bulk_query_id, _, @max_poll_count) do
+    cancel(token, bulk_query_id)
+    {:error, @polling_timeout_message}
+  end
+
+  defp poll_till_completed(token, bulk_query_id, polling_rate, depth) do
     Process.sleep(polling_rate)
 
-    {:ok, %{response: %{"currentBulkOperation" => %{"status" => status} = response}}} =
-      poll(token)
+    token
+    |> ShopifyAPI.graphql_request(@polling_query, 1)
+    |> case do
+      {:ok, %{response: %{"currentBulkOperation" => %{"status" => "COMPLETED"} = response}}} ->
+        {:ok, Map.get(response, "url")}
 
-    case status do
-      "COMPLETED" -> {:ok, Map.get(response, "url")}
-      _ -> poll_till_completed(token, polling_rate)
+      _ ->
+        poll_till_completed(token, bulk_query_id, polling_rate, depth + 1)
     end
   end
 
-  defp poll(%AuthToken{} = token) do
-    poll_query = """
-    {
-      currentBulkOperation {
-        id
-        status
-        errorCode
-        createdAt
-        completedAt
-        objectCount
-        fileSize
-        url
-        partialDataUrl
-      }
-    }
-    """
-
-    ShopifyAPI.graphql_request(token, poll_query, 1)
-  end
-
-  defp parse_bulk_response(jsonl) do
+  defp parse_bulk_response!(jsonl) do
     jsonl
-    |> String.split("\n")
-    |> Enum.drop(-1)
-    |> Enum.map(&Jason.decode!/1)
+    |> String.split("\n", trim: true)
+    |> Enum.map(&ShopifyAPI.JSONSerializer.decode!/1)
   end
 end

--- a/lib/shopify_api/graphql/bulk_fetch.ex
+++ b/lib/shopify_api/graphql/bulk_fetch.ex
@@ -86,8 +86,8 @@ defmodule ShopifyAPI.GraphQL.BulkFetch do
         }
       \"""
       iex> {:ok, token} = YourShopifyApp.ShopifyAPI.Shop.get_auth_token_from_slug("slug")
-      iex> func = fn {:ok, json} -> IO.puts(json) end # Warning we are not handling error conditions here.
-      iex> ShopifyAPI.GraphQL.BulkFetch.process_stream(token, query, func)
+      iex> ShopifyAPI.GraphQL.BulkFetch.process_stream(token, query)
+           |> Enum.map(fn {:ok, json} -> IO.puts(json) end)
   """
   @spec process_stream(AuthToken.t(), String.t(), integer()) :: Enumerable.t()
   def process_stream(%AuthToken{} = token, query, polling_rate \\ 100) do

--- a/test/shopify_api/graphql/bulk_fetch_test.exs
+++ b/test/shopify_api/graphql/bulk_fetch_test.exs
@@ -1,0 +1,87 @@
+defmodule ShopifyAPI.GraphQL.BulkFetchTest do
+  use ExUnit.Case
+
+  alias ShopifyAPI.GraphQL.BulkFetch
+
+  @valid_graphql_response %{
+    "data" => %{
+      "bulkOperationRunQuery" => %{"userErrors" => [], "bulkOperation" => %{"id" => "1"}},
+      "currentBulkOperation" => %{"status" => "COMPLETED", "url" => "here_stuff"}
+    },
+    "extensions" => %{"cost" => %{"throttleStatus" => %{"currentlyAvailable" => 1000}}}
+  }
+  @valid_jsonl_response %{val: :foo}
+  @graphql_ver "10"
+  @graphql_path "/admin/api/#{@graphql_ver}/graphql.json"
+
+  setup _context do
+    bypass = Bypass.open()
+
+    Application.put_env(:shopify_api, ShopifyAPI.GraphQL, graphql_version: @graphql_ver)
+
+    token = %ShopifyAPI.AuthToken{
+      token: "token",
+      shop_name: "localhost:#{bypass.port}"
+    }
+
+    shop = %ShopifyAPI.Shop{domain: "localhost:#{bypass.port}"}
+
+    {:ok, %{shop: shop, auth_token: token, bypass: bypass}}
+  end
+
+  test "happy path", %{bypass: bypass, shop: _shop, auth_token: token} do
+    Bypass.expect(bypass, "POST", @graphql_path, fn conn ->
+      body =
+        @valid_graphql_response
+        |> put_in(
+          ["data", "currentBulkOperation", "url"],
+          "localhost:#{bypass.port}/bulk_response"
+        )
+        |> Jason.encode!()
+
+      Plug.Conn.resp(conn, 200, body)
+    end)
+
+    Bypass.expect(bypass, "GET", "/bulk_response", fn conn ->
+      Plug.Conn.resp(conn, 200, "#{Jason.encode!(@valid_jsonl_response)}\n")
+    end)
+
+    assert {:ok, _} = BulkFetch.fetch_jsonl(token, "fake_query", 100)
+  end
+
+  test "polling timeout", %{bypass: bypass, shop: _shop, auth_token: token} do
+    Bypass.expect(bypass, "POST", @graphql_path, fn conn ->
+      body =
+        @valid_graphql_response
+        |> put_in(
+          ["data", "currentBulkOperation", "status"],
+          "INCOMPLETE"
+        )
+        |> Jason.encode!()
+
+      Plug.Conn.resp(conn, 200, body)
+    end)
+
+    resp = BulkFetch.fetch_jsonl(token, "fake_query", 1)
+    assert resp == {:error, "BulkFetch timed out before completion"}
+  end
+
+  test "invalid graphql", %{bypass: bypass, shop: _shop, auth_token: token} do
+    Bypass.expect(bypass, "POST", @graphql_path, fn conn ->
+      body =
+        @valid_graphql_response
+        |> put_in(
+          ["data", "bulkOperationRunQuery", "userErrors"],
+          [
+            %{"field" => ["query"], "message" => "Bulk query is not valid GraphQL"}
+          ]
+        )
+        |> Jason.encode!()
+
+      Plug.Conn.resp(conn, 200, body)
+    end)
+
+    resp = BulkFetch.fetch_jsonl(token, "fake_query", 100)
+    assert resp == {:error, "Bulk query is not valid GraphQL"}
+  end
+end


### PR DESCRIPTION
Adds ability to make bulk graphql queries.

Accepts a query and an optional polling rate(defaulting to 100ms), starting the job and polling until either the job is complete or the job has been polled 100 times. If completed downloads the `jsonl` result and parses it into a list of maps which is returned out of the function. 

Required a bump of the default graphql api version to 2019-19.

Bulk query shopify docs: [https://shopify.dev/tutorials/perform-bulk-operations-with-admin-api](https://shopify.dev/tutorials/perform-bulk-operations-with-admin-api)