### PR TITLE
New 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.8.2
+
 - Add throttling for GraphQL.
 - Add GraphQL bulk fetch query method.
 - Switch default version of GraphQL API to 2019-10 (was 2019-07).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.8.1"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.8.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
 
   def project do
     [


### PR DESCRIPTION
changes

 - Add throttling for GraphQL.
 - Add GraphQL bulk fetch query method.
 - Switch default version of GraphQL API to 2019-10 (was 2019-07).