### PR TITLE
Get all collections calls use the correct endpoint path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Added max poll count configuration option to GraphQL Bulk Query.
+- Fix: `all/3` for smart_collection and custom_collection works.
 
 ## 0.8.2
 

--- a/lib/shopify_api/rest/custom_collection.ex
+++ b/lib/shopify_api/rest/custom_collection.ex
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.CustomCollection do
       {:ok, [%{}, ...] = custom_collections}
   """
   def all(%AuthToken{} = auth, params \\ [], options \\ []),
-    do: REST.get(auth, "admin/custom_collections.json", params, options)
+    do: REST.get(auth, "custom_collections.json", params, options)
 
   @doc """
   Get a count of all custom collections.

--- a/lib/shopify_api/rest/smart_collection.ex
+++ b/lib/shopify_api/rest/smart_collection.ex
@@ -14,7 +14,7 @@ defmodule ShopifyAPI.REST.SmartCollection do
       {:ok, [] = smart_collections}
   """
   def all(%AuthToken{} = auth, params \\ [], options \\ []),
-    do: REST.get(auth, "admin/smart_collections.json", params, options)
+    do: REST.get(auth, "smart_collections.json", params, options)
 
   @doc """
   Get a count of all SmartCollections.


### PR DESCRIPTION
## WHAT?

`SmartCollection.all/3` and `CustomCollection.all/3` are bugged in the current implementation, the inclusion of `admin/` in the endpoint causes these functions to make a request to `https://mzs-store-of-love.myshopify.com/admin/api/2020-01/admin/smart_collections.json?` which is an invalid endpoint.

## HOW?
For both functions remove the `admin/` from the endpoints.

## TESTING?
Both functions should work.