### PR TITLE
fix recursive call for Cancel.poll missing an arguement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.8.4
+
+- Fix: `Bulk.Cancel.poll/5` uses the correct arguments while recursing.
+
 ## 0.8.3
 
 - Added max poll count configuration option to GraphQL Bulk Query.

--- a/lib/shopify_api/bulk/cancel.ex
+++ b/lib/shopify_api/bulk/cancel.ex
@@ -45,6 +45,6 @@ defmodule ShopifyAPI.Bulk.Cancel do
 
     token
     |> Query.cancel(bid)
-    |> poll(token, max_poll, depth + 1)
+    |> poll(token, bid, max_poll, depth + 1)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.8.3"
+  @version "0.8.4"
 
   def project do
     [


### PR DESCRIPTION
Handles an error where attempts to cancel a bulk query fail with:
```
%{
      "errors" => [
        %{
          "extensions" => %{
            "code" => "argumentLiteralsIncompatible",
            "typeName" => "CoercionError"
          },
          "locations" => [%{"column" => 3, "line" => 2}],
          "message" => "Invalid global id '1'",
          "path" => ["mutation", "bulkOperationCancel", "id"]
        }
      ]
    }
```

When `poll` is being recursed over, we are missing the argument for the bulk query id, so the poll counter is being used instead which ⛈shockingly Shopify doesn't like.