### PR TITLE
inc ver to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.9.0
+
 - Add HTTP fetch streaming in Bulk.Query with stream_fetch/1
 - BREAKING: Bulk.process_stream/2 is now Bulk.process_stream!/2 and no longer returns errors in a list.
   - Now streams HTTP body.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.8.2"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.9.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.8.4"
+  @version "0.9.0"
 
   def project do
     [


### PR DESCRIPTION
- Add HTTP fetch streaming in Bulk.Query with stream_fetch/1
 - BREAKING: Bulk.process_stream/2 is now Bulk.process_stream!/2 and no longer returns errors in a list.
   - Now streams HTTP body.