### PR TITLE
Decompose Router Functionality

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -6,4 +6,6 @@ config :bypass, adapter: Plug.Adapters.Cowboy2
 
 config :shopify_api,
   customer_api_secret_keys: ["new_secret", "old_secret"],
-  transport: "http://"
+  transport: "http://",
+  bypass_host: "localhost:62323",
+  bypass_port: 62323

--- a/lib/shopify_api.ex
+++ b/lib/shopify_api.ex
@@ -28,4 +28,7 @@ defmodule ShopifyAPI do
   # Override in configuration to `http://` for testing using Bypass.
   @spec transport() :: String.t()
   def transport, do: Application.get_env(:shopify_api, :transport, "https://")
+
+  @spec bypass_host() :: String.t() | nil
+  def bypass_host, do: Application.get_env(:shopify_api, :bypass_host)
 end

--- a/lib/shopify_api/app.ex
+++ b/lib/shopify_api/app.ex
@@ -77,7 +77,10 @@ defmodule ShopifyAPI.AuthRequest do
   alias ShopifyAPI.JSONSerializer
   @headers [{"Content-Type", "application/json"}]
 
-  defp access_token_url(domain), do: "#{ShopifyAPI.transport()}#{domain}/admin/oauth/access_token"
+  defp access_token_url(domain) do
+    d = if ShopifyAPI.bypass_host(), do: ShopifyAPI.bypass_host(), else: domain
+    "#{ShopifyAPI.transport()}#{d}/admin/oauth/access_token"
+  end
 
   @spec post(ShopifyAPI.App.t(), String.t(), String.t()) :: {:ok, any()} | {:error, any()}
   def post(%ShopifyAPI.App{} = app, domain, auth_code) do

--- a/lib/shopify_api/conn_helpers.ex
+++ b/lib/shopify_api/conn_helpers.ex
@@ -107,4 +107,11 @@ defmodule ShopifyAPI.ConnHelpers do
       |> Enum.join("&")
       |> Security.base16_sha256_hmac(secret)
   end
+
+  @doc false
+
+  def verify_shop_name(name) do
+    name
+    |> String.match?(~r/^[a-zA-Z0-9][a-zA-Z0-9\-]*\.myshopify\.com[\/]?/)
+  end
 end

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -60,17 +60,26 @@ defmodule ShopifyAPI.GraphQL do
     actual_cost =
       metadata
       |> get_in(["cost", "actualQueryCost"])
-      |> Kernel.trunc()
+      |> case do
+        nil -> nil
+        val -> Kernel.trunc(val)
+      end
 
     currently_available =
       metadata
       |> get_in(["cost", "throttleStatus", "currentlyAvailable"])
-      |> Kernel.trunc()
+      |> case do
+        nil -> nil
+        val -> Kernel.trunc(val)
+      end
 
     maximum_available =
       metadata
       |> get_in(["cost", "throttleStatus", "maximumAvailable"])
-      |> Kernel.trunc()
+      |> case do
+        nil -> nil
+        val -> Kernel.trunc(val)
+      end
 
     rate_limit(actual_cost, currently_available, maximum_available)
   end

--- a/lib/shopify_api/router.ex
+++ b/lib/shopify_api/router.ex
@@ -1,75 +1,21 @@
 defmodule ShopifyAPI.Router do
   use Plug.Router
-  require Logger
 
-  alias Plug.Conn
-  alias ShopifyAPI.{App, AuthToken, AuthTokenServer, ConnHelpers}
-  alias ShopifyAPI.Shop
+  alias ShopifyAPI.{ShopInstaller}
 
   plug(:match)
   plug(:dispatch)
 
+  get "/install/:app" do
+    ShopInstaller.initialize_installation(conn)
+  end
+
   get "/install" do
-    conn
-    |> ConnHelpers.fetch_shopify_app()
-    |> case do
-      {:ok, app} ->
-        install_url = App.install_url(app, ConnHelpers.shop_domain(conn))
-
-        conn
-        |> Conn.put_resp_header("location", install_url)
-        |> Conn.resp(unquote(302), "You are being redirected.")
-        |> Conn.halt()
-
-      res ->
-        Logger.info("#{__MODULE__} failed install with: #{res}")
-
-        conn
-        |> Conn.resp(404, "Not Found.")
-        |> Conn.halt()
-    end
+    ShopInstaller.initialize_installation(conn)
   end
 
   # Shopify Callback on App authorization
   get "/authorized/:app" do
-    Logger.info("Authorized #{ConnHelpers.shop_domain(conn)}")
-
-    with {:ok, app} <- ConnHelpers.fetch_shopify_app(conn),
-         true <- ConnHelpers.verify_nonce(app, conn.query_params),
-         true <- ConnHelpers.verify_params_with_hmac(app, conn.query_params),
-         {:ok, auth_token} <- request_auth_token(conn, app) do
-      Shop.post_install(auth_token)
-      AuthTokenServer.set(auth_token)
-
-      conn
-      |> Conn.resp(200, "Authenticated.")
-      |> Conn.halt()
-    else
-      res ->
-        Logger.info("#{__MODULE__} failed authorized with: #{inspect(res)}")
-
-        conn
-        |> Conn.resp(404, "Not Found.")
-        |> Conn.halt()
-    end
-  end
-
-  defp request_auth_token(conn, app) do
-    app
-    |> App.fetch_token(ConnHelpers.shop_domain(conn), ConnHelpers.auth_code(conn))
-    |> case do
-      {:ok, token} ->
-        {:ok,
-         %AuthToken{
-           app_name: ConnHelpers.app_name(conn),
-           shop_name: ConnHelpers.shop_domain(conn),
-           code: ConnHelpers.auth_code(conn),
-           timestamp: String.to_integer(conn.query_params["timestamp"]),
-           token: token
-         }}
-
-      _msg ->
-        {:error, "unable to fetch token"}
-    end
+    ShopInstaller.complete_installation(conn)
   end
 end

--- a/lib/shopify_api/shop_installer.ex
+++ b/lib/shopify_api/shop_installer.ex
@@ -38,10 +38,10 @@ defmodule ShopifyAPI.ShopInstaller do
   @spec complete_installation(Plug.Conn.t()) :: {:ok, any()} | {:error, any()}
   def complete_installation(conn) do
     case authorize_shop(conn) do
-      {:ok, resp} ->
+      {:ok, _resp} ->
         render_authenticated_response(conn)
 
-      {:error, msg} ->
+      {:error, _msg} ->
         halt_install(conn)
     end
   end

--- a/lib/shopify_api/shop_installer.ex
+++ b/lib/shopify_api/shop_installer.ex
@@ -1,0 +1,133 @@
+defmodule ShopifyAPI.ShopInstaller do
+  require Logger
+
+  alias Plug.Conn
+
+  alias ShopifyAPI.{App, AuthToken, AuthTokenServer, ConnHelpers}
+  alias ShopifyAPI.Shop
+
+  @spec initialize_installation(Plug.Conn.t()) :: Plug.Conn.t()
+  def initialize_installation(conn) do
+    conn
+    |> generate_install_url_for_app()
+    |> case do
+      {:ok, install_url} ->
+        redirect_to_shopify_installer(conn, install_url)
+
+      {:error, res} ->
+        Logger.info("#{__MODULE__} failed install with: #{res}")
+        halt_install(conn)
+    end
+  end
+
+  defp generate_install_url_for_app(%Plug.Conn{} = conn) do
+    with {:ok, app} <- ConnHelpers.fetch_shopify_app(conn) do
+      domain = ConnHelpers.shop_domain(conn)
+      install_url_for_app(app, domain)
+    else
+      _ ->
+        {:error, "unable to fetch shopify app store"}
+    end
+  end
+
+  defp install_url_for_app(app, domain) do
+    install_url = App.install_url(app, domain)
+    {:ok, install_url}
+  end
+
+  @spec complete_installation(Plug.Conn.t()) :: {:ok, any()} | {:error, any()}
+  def complete_installation(conn) do
+    case authorize_shop(conn) do
+      {:ok, resp} ->
+        render_authenticated_response(conn)
+
+      {:error, msg} ->
+        halt_install(conn)
+    end
+  end
+
+  @spec authorize_shop(Plug.Conn.t()) :: {:ok, any()} | {:error, any()}
+  def authorize_shop(conn) do
+    case ConnHelpers.fetch_shopify_app(conn) do
+      {:ok, app} ->
+        update_token_for(conn, app)
+
+      _ ->
+        Logger.debug("app #{ConnHelpers.app_name(conn)} not found")
+        {:error, "unable to fetch app"}
+    end
+  end
+
+  defp update_token_for(conn, app) do
+    if valid_auth_request?(conn, app) do
+      Logger.debug("Authorized #{ConnHelpers.shop_domain(conn)}")
+      config_auth_token(conn, app)
+    else
+      Logger.debug("#{__MODULE__} invalid request for #{ConnHelpers.shop_domain(conn)}. halting.")
+      {:error, "invalid auth request received"}
+    end
+  end
+
+  defp valid_auth_request?(conn, app) do
+    nonce_verified = ConnHelpers.verify_nonce(app, conn.query_params)
+    params_verified = ConnHelpers.verify_params_with_hmac(app, conn.query_params)
+    shop_name_verified = ConnHelpers.verify_shop_name(ShopifyAPI.ConnHelpers.shop_domain(conn))
+
+    Logger.debug(
+      "request: nonce: #{nonce_verified} params: #{params_verified} shop_name: #{
+        shop_name_verified
+      } #{ShopifyAPI.ConnHelpers.shop_domain(conn)}"
+    )
+
+    nonce_verified && params_verified && shop_name_verified
+  end
+
+  defp config_auth_token(conn, app) do
+    with {:ok, auth_token} <- request_permanent_token(conn, app) do
+      Shop.post_install(auth_token)
+      AuthTokenServer.set(auth_token)
+      {:ok, "authorized"}
+    else
+      {:error, resp} ->
+        {:error, "unable to fetch auth_token #{inspect(resp)}"}
+    end
+  end
+
+  defp request_permanent_token(conn, app) do
+    app
+    |> App.fetch_token(ConnHelpers.shop_domain(conn), ConnHelpers.auth_code(conn))
+    |> case do
+      {:ok, token} ->
+        {:ok,
+         %AuthToken{
+           app_name: ConnHelpers.app_name(conn),
+           shop_name: ConnHelpers.shop_domain(conn),
+           code: ConnHelpers.auth_code(conn),
+           timestamp: String.to_integer(conn.query_params["timestamp"]),
+           token: token
+         }}
+
+      _msg ->
+        {:error, "unable to fetch token"}
+    end
+  end
+
+  defp render_authenticated_response(conn) do
+    conn
+    |> Conn.resp(200, "Authenticated.")
+    |> Conn.halt()
+  end
+
+  defp redirect_to_shopify_installer(conn, url) do
+    conn
+    |> Conn.put_resp_header("location", url)
+    |> Conn.resp(unquote(302), "You are being redirected.")
+    |> Conn.halt()
+  end
+
+  defp halt_install(conn) do
+    conn
+    |> Conn.resp(404, "Not Found.")
+    |> Conn.halt()
+  end
+end


### PR DESCRIPTION
This modification decomposes some functions in ShopifyAPI.Router so that
the underlying logic is available outside of the router context. It
also breaks down the flow of logic so that it's more self-documenting
regarding what it's doing.

Logic is moved to the ShopInstaller module and the Router module is left
to do routing type things.

The update also adds verification of the shopify store name (as
documented in Shopify documentation as an expected validation that
occurs).

Addition of shop name checking requires us to override some behavior by
environment. Because we're using a Bypass server instead of a mock,
we need to override the behavior in logic so that it handles both the
request to the alternate service while still allowing the check for the
shop name.