### PR TITLE
Upgrade default Shopify API version to 2020-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - BREAKING: Rename `ShopifyAPI.CacheSupervisor` to `ShopifyAPI.Supervisor`.
 - Upgrade `AppServer`, `ShopServer`, and `AuthTokenServer` to use ets-backed caching.
+- Change default Shopify API version to `2020-10`.
 
 ## 0.9.4
 

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -9,7 +9,7 @@ defmodule ShopifyAPI.GraphQL do
   alias ShopifyAPI.GraphQL.{JSONParseError, Response, Telemetry}
   alias ShopifyAPI.JSONSerializer
 
-  @default_graphql_version "2019-10"
+  @default_graphql_version "2020-10"
 
   @log_module __MODULE__ |> to_string() |> String.trim_leading("Elixir.")
 

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -12,7 +12,7 @@ defmodule ShopifyAPI.REST.Request do
   alias HTTPoison.Error
   alias ShopifyAPI.{AuthToken, JSONSerializer, RateLimiting, Throttled}
 
-  @default_api_version "2020-01"
+  @default_api_version "2020-10"
 
   @http_receive_timeout Application.get_env(:shopify_api, :http_timeout)
 


### PR DESCRIPTION
Release notes for this most recent version: https://shopify.dev/concepts/about-apis/versioning/release-notes/2020-10
Closes #309 