### PR TITLE
bump ver to 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.10.0
+
 - BREAKING: Rename `ShopifyAPI.CacheSupervisor` to `ShopifyAPI.Supervisor`.
 - Upgrade `AppServer`, `ShopServer`, and `AuthTokenServer` to use ets-backed caching.
 - Change default Shopify API version to `2020-10`.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.9.4"
+  @version "0.10.0"
 
   def project do
     [


### PR DESCRIPTION
Cutting a new release


Changes:

- BREAKING: Rename `ShopifyAPI.CacheSupervisor` to `ShopifyAPI.Supervisor`.
- Upgrade `AppServer`, `ShopServer`, and `AuthTokenServer` to use ets-backed caching.
- Change default Shopify API version to `2020-10`.
- BREAKING: Remove GraphQL App/Shop/AuthToken servers.
  - If you want this/use this, grab it out of the git history and import in to your project.
- Fix a pattern match bug in REST.RecurringApplicationCharge.create/2
