### PR TITLE
rest access scopes are a unique snowflake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Add: REST.Redirect - thanks @tres
+- Fix: Broken path for REST.AccessScopes.get/1
 
 ## 0.10.0
 

--- a/lib/shopify_api/rest/access_scope.ex
+++ b/lib/shopify_api/rest/access_scope.ex
@@ -18,7 +18,7 @@ defmodule ShopifyAPI.REST.AccessScope do
     do:
       REST.get(
         auth,
-        "oauth/access_scopes.json",
+        "/admin/oauth/access_scopes.json",
         params,
         Keyword.merge([pagination: :none], options)
       )

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -197,8 +197,12 @@ defmodule ShopifyAPI.REST.Request do
 
   defp remaining_calls(_), do: nil
 
-  defp url(%{shop_name: domain}, path),
-    do: "#{ShopifyAPI.transport()}#{domain}/admin/api/#{version()}/#{path}"
+  # Absolute URL generator
+  defp url(%{shop_name: domain}, <<?/, path::binary>>),
+    do: "#{ShopifyAPI.transport()}#{domain}/#{path}"
+
+  # Relative with version URL generator
+  defp url(shop, path), do: url(shop, "/admin/api/#{version()}/#{path}")
 
   defp headers(%{token: access_token}) do
     [


### PR DESCRIPTION
REST Access Scope path is different from all the other  REST API endpoints.

Added a REST.Request.url/2 match so you can provide it with an absolute URL, overriding the default inclusion of /admin and versioning information.

co-author: greg.daynes@pixelunion.net