### PR TITLE
Adding specs to shopserver public functions

### DIFF
--- a/lib/shopify_api/app_server.ex
+++ b/lib/shopify_api/app_server.ex
@@ -14,20 +14,20 @@ defmodule ShopifyAPI.AppServer do
     |> Map.new()
   end
 
-  def count do
-    :ets.info(@table, :size)
-  end
+  @spec count() :: integer()
+  def count, do: :ets.info(@table, :size)
 
-  def set(%App{name: name} = app) do
-    set(name, app)
-  end
+  @spec set(App.t()) :: :ok
+  def set(%App{name: name} = app), do: set(name, app)
 
+  @spec set(String.t(), App.t()) :: :ok
   def set(name, %App{} = app) do
     :ets.insert(@table, {name, app})
     do_persist(app)
     :ok
   end
 
+  @spec get(String.t()) :: {:ok, App.t()} | :error
   def get(name) do
     case :ets.lookup(@table, name) do
       [{^name, app}] -> {:ok, app}

--- a/lib/shopify_api/auth_token_server.ex
+++ b/lib/shopify_api/auth_token_server.ex
@@ -14,15 +14,16 @@ defmodule ShopifyAPI.AuthTokenServer do
     |> Map.new()
   end
 
-  def count do
-    :ets.info(@table, :size)
-  end
+  @spec count() :: integer()
+  def count, do: :ets.info(@table, :size)
 
+  @spec set(AuthToken.t()) :: :ok
   def set(%AuthToken{} = token, persist? \\ true) do
     :ets.insert(@table, {{token.shop_name, token.app_name}, token})
     if persist?, do: do_persist(token)
   end
 
+  @spec get(String.t(), String.t()) :: {:ok, AuthToken.t()} | {:error, String.t()}
   def get(shop, app) when is_binary(shop) and is_binary(app) do
     case :ets.lookup(@table, {shop, app}) do
       [{_key, token}] -> {:ok, token}

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -14,16 +14,17 @@ defmodule ShopifyAPI.ShopServer do
     |> Map.new()
   end
 
-  def count do
-    :ets.info(@table, :size)
-  end
+  @spec count() :: integer()
+  def count, do: :ets.info(@table, :size)
 
+  @spec set(Shop.t()) :: :ok
   def set(%Shop{domain: domain} = shop) do
     :ets.insert(@table, {domain, shop})
     do_persist(shop)
     :ok
   end
 
+  @spec get(String.t()) :: {:ok, Shop.t()} | :error
   def get(domain) do
     case :ets.lookup(@table, domain) do
       [{^domain, shop}] -> {:ok, shop}


### PR DESCRIPTION
Got bit by this with the recent 0.10, previously the set/1 function would accept a map.  It doesn't any more and there were no specs to let dialyzer know the new stricter function def would fail.