### PR TITLE
set used to return :ok, it still should

### DIFF
--- a/lib/shopify_api/auth_token_server.ex
+++ b/lib/shopify_api/auth_token_server.ex
@@ -21,6 +21,7 @@ defmodule ShopifyAPI.AuthTokenServer do
   def set(%AuthToken{} = token, persist? \\ true) do
     :ets.insert(@table, {{token.shop_name, token.app_name}, token})
     if persist?, do: do_persist(token)
+    :ok
   end
 
   def get(shop, app) when is_binary(shop) and is_binary(app) do


### PR DESCRIPTION
set used to return :ok, it still should

- This was a regression with the move to ets tables
- All other cache server set/1 func return :ok on success