### PR TITLE
Chore/allow options for fulfillment create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - BREAKING: removed Elixir 1.9 and OTP 21 support
 - Switch `ShopifyAPI.JSONSerializer` to be configured at compile-time, not runtime.
+- BREAKING: Rename Shopify API environment variable from `http_timeout` to `rest_recv_timeout`
+- Add the ability to pass a list of HTTPoison options to `Rest.post` and `Rest.put`
+  - Add 4th param to ShopifyAPI.REST.Fulfillment.create/4
 
 ## 0.10.3
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,7 @@ config :shopify_api, ShopifyAPI.Webhook, %{
 }
 
 config :shopify_api,
-  http_timeout: 5000
+  rest_recv_timeout: 5000
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/shopify_api/rest.ex
+++ b/lib/shopify_api/rest.ex
@@ -57,24 +57,24 @@ defmodule ShopifyAPI.REST do
   end
 
   @doc false
-  def post(%AuthToken{} = auth, path, object \\ %{}) do
+  def post(%AuthToken{} = auth, path, object \\ %{}, options \\ []) do
     with {:ok, body} <- JSONSerializer.encode(object) do
-      perform_request(auth, :post, path, body)
+      perform_request(auth, :post, path, body, options)
     end
   end
 
   @doc false
-  def put(%AuthToken{} = auth, path, object) do
+  def put(%AuthToken{} = auth, path, object, options \\ []) do
     with {:ok, body} <- JSONSerializer.encode(object) do
-      perform_request(auth, :put, path, body)
+      perform_request(auth, :put, path, body, options)
     end
   end
 
   @doc false
   def delete(%AuthToken{} = auth, path), do: perform_request(auth, :delete, path)
 
-  defp perform_request(auth, method, path, body \\ "") do
-    with {:ok, response} <- Request.perform(auth, method, path, body),
+  defp perform_request(auth, method, path, body \\ "", options \\ []) do
+    with {:ok, response} <- Request.perform(auth, method, path, body, [], options),
          response_body <- fetch_body(response) do
       {:ok, response_body}
     end

--- a/lib/shopify_api/rest/fulfillment.ex
+++ b/lib/shopify_api/rest/fulfillment.ex
@@ -59,8 +59,9 @@ defmodule ShopifyAPI.REST.Fulfillment do
       iex> ShopifyAPI.REST.Fulfillment.create(auth, string, map)
       {:ok, %{} = fulfillment}
   """
-  def create(%AuthToken{} = auth, order_id, %{fulfillment: %{}} = fulfillment),
-    do: REST.post(auth, "orders/#{order_id}/fulfillments.json", fulfillment)
+  def create(%AuthToken{} = auth, order_id, %{fulfillment: %{}} = fulfillment, options \\ []) do
+    REST.post(auth, "orders/#{order_id}/fulfillments.json", fulfillment, options)
+  end
 
   @doc """
   Update an existing fulfillment.


### PR DESCRIPTION
 When creating a Fulfillment in Shopify, requests are allowed to take up to 40s before timing out. Added options to `fulfillment.create/4` to override the `recv_timeout` option.