### PR TITLE
Refactor JSONSerializer to be configured at compile-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - BREAKING: removed Elixir 1.9 and OTP 21 support
+- Switch `ShopifyAPI.JSONSerializer` to be configured at compile-time, not runtime.
 
 ## 0.10.3
 

--- a/lib/shopify_api/graphql/response.ex
+++ b/lib/shopify_api/graphql/response.ex
@@ -32,7 +32,6 @@ defmodule ShopifyAPI.GraphQL.Response do
     case JSONSerializer.decode(response.body) do
       {:ok, body} -> build_response(%{response | body: body})
       {:error, error} -> handle_unparsable(response, error)
-      {:error, error, _} -> handle_unparsable(response, error)
     end
   end
 

--- a/lib/shopify_api/json_serializer.ex
+++ b/lib/shopify_api/json_serializer.ex
@@ -1,17 +1,21 @@
 defmodule ShopifyAPI.JSONSerializer do
   @moduledoc """
-  JSONSerializer provides a wrapper for JSON serialization which is configurable via the :shopify_api application configuration. It defaults to Poison for legacy support.
+  Abstraction point allowing for use of a custom JSON serializer, if your app requires it.
+  By default `shopify_api` uses the popular Jason, but you can override in your app config:
 
+      # use Poison to encode/decode JSON
+      config :shopify_api, :json_library, Poison
 
-  Add the following to your configuration to override:
-  ```
-  config :shopify_api, json_library: Jason
-  ```
+  After doing so, you must make sure to re-compile the `shopify_api` dependency:
+
+      $ mix deps.compile --force shopify_api
   """
 
-  def decode(json), do: json_library().decode(json)
-  def encode(e), do: json_library().encode(e)
-  def decode!(json), do: json_library().decode!(json)
-  def encode!(e), do: json_library().encode!(e)
-  defp json_library, do: Application.get_env(:shopify_api, :json_library, Jason)
+  @codec Application.compile_env(:shopify_api, :json_library, Jason)
+
+  defdelegate encode(json_str), to: @codec
+  defdelegate decode(json_str), to: @codec
+
+  defdelegate encode!(json_str), to: @codec
+  defdelegate decode!(json_str), to: @codec
 end

--- a/lib/shopify_api/json_serializer.ex
+++ b/lib/shopify_api/json_serializer.ex
@@ -1,7 +1,7 @@
 defmodule ShopifyAPI.JSONSerializer do
   @moduledoc """
   Abstraction point allowing for use of a custom JSON serializer, if your app requires it.
-  By default `shopify_api` uses the popular Jason, but you can override in your app config:
+  By default `shopify_api` uses the popular `jason`, you can override this in your config:
 
       # use Poison to encode/decode JSON
       config :shopify_api, :json_library, Poison

--- a/lib/shopify_api/plugs/customer_authenticator.ex
+++ b/lib/shopify_api/plugs/customer_authenticator.ex
@@ -150,13 +150,4 @@ defmodule ShopifyAPI.Plugs.CustomerAuthenticator do
 
   defp handle_error(conn, {:error, _}),
     do: send_unauthorized_response(conn, "Could not parse auth_payload")
-
-  defp handle_error(conn, {:error, _, _}),
-    do: send_unauthorized_response(conn, "Could not parse auth_payload")
-
-  defp handle_error(conn, _error) do
-    conn
-    |> resp(500, "Unhandled Error")
-    |> halt()
-  end
 end


### PR DESCRIPTION
It is... exceptionally unlikely we'll want this to change at runtime.

As a result, we can statically compile these pieces together, and avoid a runtime call to fetch this bit of configuration every time we want to JSON encode/decode something.