### PR TITLE
Bump release to v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.11.0
+
 - BREAKING: removed Elixir 1.9 and OTP 21 support
 - Switch `ShopifyAPI.JSONSerializer` to be configured at compile-time, not runtime.
 - BREAKING: Rename Shopify API environment variable from `http_timeout` to `rest_recv_timeout`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.9.4"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.11.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.10.3"
+  @version "0.11.0"
 
   def project do
     [


### PR DESCRIPTION
- BREAKING: removed Elixir 1.9 and OTP 21 support
- Switch `ShopifyAPI.JSONSerializer` to be configured at compile-time, not runtime.
- BREAKING: Rename Shopify API environment variable from `http_timeout` to `rest_recv_timeout`
- Add the ability to pass a list of HTTPoison options to `Rest.post` and `Rest.put`
  - Add 4th param to ShopifyAPI.REST.Fulfillment.create/4