### PR TITLE
Add ets delete

### DIFF
--- a/lib/shopify_api/auth_token_server.ex
+++ b/lib/shopify_api/auth_token_server.ex
@@ -45,13 +45,13 @@ defmodule ShopifyAPI.AuthTokenServer do
   @spec drop(String.t(), String.t()) :: {:ok, true}
   def drop(shop, app), do: {:ok, :ets.delete(@table, {shop, app})}
 
-
   @spec drop!(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def drop!(shop, app) when is_binary(shop) and is_binary(app) do
     case get(shop, app) do
       {:ok, _} ->
         :ets.delete(@table, {shop, app})
         {:ok, "Auth token for #{shop}:#{app} deleted"}
+
       {:error, _} ->
         {:error, "Auth token for #{shop}:#{app} could not be deleted. Auth token not found"}
     end

--- a/lib/shopify_api/auth_token_server.ex
+++ b/lib/shopify_api/auth_token_server.ex
@@ -42,6 +42,21 @@ defmodule ShopifyAPI.AuthTokenServer do
     :ets.select(@table, match_spec)
   end
 
+  @spec drop(String.t(), String.t()) :: {:ok, true}
+  def drop(shop, app), do: {:ok, :ets.delete(@table, {shop, app})}
+
+
+  @spec drop!(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def drop!(shop, app) when is_binary(shop) and is_binary(app) do
+    case get(shop, app) do
+      {:ok, _} ->
+        :ets.delete(@table, {shop, app})
+        {:ok, "Auth token for #{shop}:#{app} deleted"}
+      {:error, _} ->
+        {:error, "Auth token for #{shop}:#{app} could not be deleted. Auth token not found"}
+    end
+  end
+
   def drop_all do
     :ets.delete_all_objects(@table)
   end

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -33,7 +33,7 @@ defmodule ShopifyAPI.ShopServer do
   end
 
   @spec drop(String.t()) :: {:ok, true}
-  def drop(domain), do: {:ok,  :ets.delete(@table, domain)}
+  def drop(domain), do: {:ok, :ets.delete(@table, domain)}
 
   @spec drop!(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def drop!(domain) do
@@ -41,6 +41,7 @@ defmodule ShopifyAPI.ShopServer do
       {:ok, _} ->
         :ets.delete(@table, domain)
         {:ok, "Shop for #{domain} deleted"}
+
       _ ->
         {:error, "Shop for #{domain} could not be deleted deleted. Shop not found"}
     end

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -32,6 +32,20 @@ defmodule ShopifyAPI.ShopServer do
     end
   end
 
+  @spec drop(String.t()) :: {:ok, true}
+  def drop(domain), do: {:ok,  :ets.delete(@table, domain)}
+
+  @spec drop!(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def drop!(domain) do
+    case get(domain) do
+      {:ok, _} ->
+        :ets.delete(@table, domain)
+        {:ok, "Shop for #{domain} deleted"}
+      _ ->
+        {:error, "Shop for #{domain} could not be deleted deleted. Shop not found"}
+    end
+  end
+
   ## GenServer Callbacks
 
   def start_link(_opts) do


### PR DESCRIPTION
This adds some logic to handle removing cached Shop / AuthToken data so that we can handle GDPR callbacks & remove cached data so that the shop data is deleted from the system as requested. 

This would also close a hole between an action that removed persisted data from the database and the cached data in the ETS table which would indicate that there is a valid shop / auth entity available for the request. 