### PR TITLE
Get OAuth Flow Working

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,31 +26,211 @@ def deps do
 end
 ```
 
-Add it to your phoenix routes.
+### Configuring Routes
+You'll need to set up some routes in your Phoenix app routes to handle installation and authorization callbacks from Shopify. 
+
+These will then need to be configured in the App setup page in Shopify. 
+
+#### Built-in ShopifyAPI Routes
+The ShopifyAPI library provides some convenience routes to you if you don't have a need to do any custom handling of authorization requests from Shopify.
+Simply set a forwarding route in your Phoenix routes like this:
 
 ```elixir
 scope "/shop" do
   forward("/", ShopifyAPI.Router)
 end
+
 ```
 
+Once that's done, you can set up your `App URL` in Shopify's App Configuration interface so it's using:
+`[MY_APP_URL]/shop/start/[MY_APP_NAME]`
+
+(where MY_APP_URL is the full url to your app and MY_APP_NAME is the `name` of your app as defined in the ShopifyAPI `App` entity -- the value stored in the local database, not the name of the app in Shopify.)
+
+And you can set your `Allowed redirection URL(s)` in Shopify's App Configuration interface to:
+```
+[MY_APP_URL]/shop/install/[MY_APP_NAME]
+[MY_APP_URL]/shop/run/[MY_APP_NAME]
+```
+
+
+for example, if I had an app I named `my_super_app` and my app were hosted at "https://shopify_apps.mydomain.com" and I set up my Phoenix routes as described above, then I'd configure Shopify's admin interface for my App so it used:
+`https://shopify_apps.mydomain.com/shop/start/my_super_app`
+for the `App URL` setting
+and contained
+```
+ https://shopify_apps.mydomain.com/shop/install/my_super_app
+ https://shopify_apps.mydomain.com/shop/run/my_super_app
+ ```
+ in the `Allowed redirection URL(s)` text area
+
+### Handling Incoming Requests From Shopify
+When using built-in routes, you'll need to configure the ShopifyAPI.Authorizer callbacks to handle incoming requests and forward them to your application controller logic.
+ 
+In order to get things working, we need to ensure that Shopify can reach our server and that when it does reach our server that our app is handling things like we want it to. 
+ 
+To do that, we configure the `ShopifyAPI.Authorizer` callbacks so that after ShopifyAPI handles a successful installation or authorization request that our app logic takes over.
+ 
+ To set things up, we'll need something like the following set up in our Application configuration files.
+ 
+ ```elixir
+  config :shopify_api, ShopifyAPI.Authorizer,
+         uri: Application.fetch_env!(:shopify_app, :shopify_conf)[:apps_base_url],
+         post_install: {MyAppWeb.AppController, :post_install},
+         run_app: {MyAppWeb.AppController, :run_app}
+
+```
+
+and the analog logic set up and ready to handle these requests. 
+
+For example:
+ 
+ ```elixir
+# config.exs
+import Config
+...
+  # this is the full url to your app as would be required by Shopify to reach your server. 
+  # additionally, the path to the mounted ShopifyAPI routes is appended
+config :shopify_app, :shopify_conf,
+       apps_base_url: "#{System.get_env("APP_HOST_URI")}"
+
+...
+```
+
+```elixir
+
+defmodule MyAppWeb.AppController do
+  def post_install(conn) do
+    ...
+  end
+
+  def run_app(conn) do
+    ...
+  end
+end
+```
+
+#### Custom Routes
+If you'd prefer not to use the built-in routes provided by ShopifyAPI, you can set up your own & hook ShopifyAPI's authorization logic into your controller.
+
+##### Custom Authorization Route
+The first route will be for handling incoming app requests to your server. 
+
+for example:
+```elixir
+    get "/app/start/:app_name", MyApp.AppController, :authorize_request
+```
+
+This will be the URI you've configured as the `App URL` in the `URLs` section of your App setup in Shopify.
+
+If you don't need to add any custom handling logic to the incoming request, you can use the 
+built-in ShopifyAPI library initialization logic by configuring `App URL` in the `URLs` section of your App setup in Shopify to go to `[YOUR APP URL]/[]
+
+##### Custom Installation Route
+ This will be where users are redirected to after they've installed your app in their shop in Shopify. Because the app installation process for an embedded app requires breaking out of the app iframe in shopify ([as seen here](https://shopify.dev/tools/app-bridge/getting-started#authenticate-with-oauth)), you may want to have a separate, dedicated app installation route set up, and special logic for handling the completion of the app installation. This will be configured as one of your `Allowed Redirection URLs` in the `URLs` Section of your App setup in Shopify.
+
+for example:
+```elixir
+    get "app/install/:app_name", MyApp.AppController, :finish_app_install
+
+```
+
+##### Custom App Run Route
+This is the route to your application logic. This will be configured as one of your `Allowed Redirection URLs` in the `URLs` Section of your App setup in Shopify.
+
+for example:
+```elixir
+    get "/app/run/:app_name", MyApp.AppController, :run_app
+```
+
+
+### Configuring Webhooks
 If you want to be able to handle webhooks you need to add this to your endpoint before the parsers section
 ```elixir
 plug(ShopifyAPI.Plugs.Webhook, mount: "/shop/webhook")
 ```
 
-If you want persisted Apps, Shops, and Tokens add configuration to your functions.
+### Configuring Library Callback Hooks
+The following callback hooks are provided so that you can hook your own logic into events as they occur.
+
+#### Data Persistence Callbacks
+If you want persisted Apps, Shops, and Tokens, use the following hooks.
+
+##### `AuthTokenServer` callbacks
+`AuthTokenServer` provides you two callback mechanisms to hook into: `initializer` to handle hydrating the datastore from your database on app start and `persistance` to allow you to store AuthToken data in your database.
+
 ```elixir
 config :shopify_api, ShopifyAPI.AuthTokenServer,
   initializer: {MyApp.AuthToken, :init, []},
   persistance: {MyApp.AuthToken, :save, []}
+```
+* `initializer` Use this callback to provide your app a way to hydrate the AuthTokenServer data store on application startup.
+* `persistance` Use this callback to provide your app a way to persist AuthToken data.
+
+##### `AppServer` callbacks
+`AppServer` provides you two callback mechanisms to hook into: `initializer` to handle hydrating the AuthTokenServer datastore from your database on app start and `persistance` to allow you to store App data in your database.
+
+```elixir
 config :shopify_api, ShopifyAPI.AppServer,
   initializer: {MyApp.ShopifyApp, :init, []},
   persistance: {MyApp.ShopifyApp, :save, []}
+```
+* `initializer` Use this callback to provide your app a way to hydrate the AppServer data store on application startup.
+* `persistance` Use this callback to provide your app a way to persist AppServer data.
+
+##### `ShopServer` callbacks
+`ShopServer` provides you two callback mechanisms to hook into: `initializer` to handle hydrating the ShopServer datastore from your database on app start and `persistance` to allow you to store Shop data in your database.
+
+```elixir
 config :shopify_api, ShopifyAPI.ShopServer,
   initializer: {MyApp.Shop, :init, []},
   persistance: {MyApp.Shop, :save, []}
 ```
+* `initializer` Use this callback to provide your app a way to hydrate the ShopServer data store on application startup.
+* `persistance` Use this callback to provide your app a way to persist ShopServer data.
+
+##### `Shop` callbacks
+```elixir
+  config :shopify_api, ShopifyAPI.Shop,
+         post_install: {MyApp.Shop, :post_app_install_callback, []}
+```
+* `post_install` Use this callback to provide your app a way to perform custom actions to take place after the application has been installed in a shop. 
+
+#### OAuth Callbacks
+
+##### `App` callbacks
+These callbacks are used in the Shopify OAuth flow. They give you the ability to define the URI
+that Shopify will redirect to after installing the app, and the one Shopify will go to after Shopify 
+has authorized the request to your app. These should be the routes you've set up in your Phoenix app.
+
+These URLs would need to be configured in the Shopify App setup interface under the
+`Allowed redirection URL(s)` section in order to work.
+
+```elixir
+  config :shopify_api, ShopifyAPI.App,
+         install_uri: {MyApp.App, :install_uri, []},
+         run_url: {MyApp.App, :run_url, []}
+```
+
+* `install_uri` Use this callback to give your app a way to show a custom page or to perform some custom logic once the app has been installed. This will only be performed once -- upon completion of installation of the app in the store.
+* `run_url` Use this callback as a hook to start your application logic once the OAuth authentication process has completed. This will be performed every time the app is started and the request has been authenticated by Shopify.
+
+When using this, your callback functions should handle a `app:` named argument when generating the uri. 
+
+For example:
+
+```elixir
+defmodule MyApp.App do
+    def install_uri(app: %ShopifyAPI.App{} = app) do
+          "https://testapp.ngrok.io/shop/install/#{app.name}"
+    end
+
+    def run_url(app: %ShopifyAPI.App{} = app) do
+          "https://testapp.ngrok.io/shop/run/#{app.name}"
+    end
+end
+```
+
 
 ## Installing this app in a Shop
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,4 +6,6 @@ config :bypass, adapter: Plug.Adapters.Cowboy2
 
 config :shopify_api,
   customer_api_secret_keys: ["new_secret", "old_secret"],
-  transport: "http://"
+  transport: "http://",
+  bypass_host: "localhost:62323",
+  bypass_port: 62323

--- a/lib/shopify_api.ex
+++ b/lib/shopify_api.ex
@@ -28,4 +28,7 @@ defmodule ShopifyAPI do
   # Override in configuration to `http://` for testing using Bypass.
   @spec transport() :: String.t()
   def transport, do: Application.get_env(:shopify_api, :transport, "https://")
+
+  @spec bypass_host() :: String.t() | nil
+  def bypass_host, do: Application.get_env(:shopify_api, :bypass_host)
 end

--- a/lib/shopify_api/authorizer.ex
+++ b/lib/shopify_api/authorizer.ex
@@ -1,0 +1,397 @@
+defmodule ShopifyAPI.Authorizer do
+  require Logger
+
+  alias Plug.Conn
+
+  alias ShopifyAPI.{
+    App,
+    AuthToken,
+    AuthTokenServer,
+    Config,
+    ConnHelpers,
+    Shop,
+    ShopifyAuthRequest,
+    ShopServer
+  }
+
+  @spec authorize_request(Plug.Conn.t()) :: Plug.Conn.t()
+  def authorize_request(conn) do
+    Logger.debug(
+      "#{__MODULE__} received initialization request for " <>
+        "shop: #{ConnHelpers.shop_domain(conn)} " <>
+        "app: #{ConnHelpers.app_name(conn)}"
+    )
+
+    if app_installed_in_shop?(conn),
+      do: authorize_run_request(conn),
+      else: initialize_installation(conn)
+  end
+
+  @spec app_installed_in_shop?(Plug.Conn.t()) :: boolean()
+  def app_installed_in_shop?(conn) do
+    shop_domain = ConnHelpers.shop_domain(conn)
+
+    found =
+      case ShopServer.get(shop_domain) do
+        {:ok, _} -> true
+        :error -> false
+      end
+
+    Logger.debug(
+      "#{__MODULE__} determining if app is already installed in shop '#{shop_domain} -- #{found}'"
+    )
+
+    found
+  end
+
+  @spec authorize_run_request(Plug.Conn.t()) :: Plug.Conn.t()
+  def authorize_run_request(conn) do
+    Logger.debug(
+      "#{__MODULE__} app already installed in shop. Authorizing request with shopify " <>
+        "shop: #{ConnHelpers.shop_domain(conn)} " <>
+        "app: #{ConnHelpers.app_name(conn)}"
+    )
+
+    case generate_authorization_uri(conn) do
+      {:ok, auth_uri} ->
+        redirect_to_shopify_auth(conn, auth_uri)
+
+      {:error, res} ->
+        Logger.info("#{__MODULE__} failed to run with: #{res}")
+        halt_install(conn)
+    end
+  end
+
+  @spec initialize_installation(Plug.Conn.t()) :: Plug.Conn.t()
+  def initialize_installation(conn) do
+    case generate_install_uri(conn) do
+      {:ok, install_uri} ->
+        redirect_to_shopify_auth(conn, install_uri)
+
+      {:error, res} ->
+        Logger.info("#{__MODULE__} failed install with: #{res}")
+        halt_install(conn)
+    end
+  end
+
+  defp generate_authorization_uri(%Plug.Conn{} = conn) do
+    case ConnHelpers.fetch_shopify_app(conn) do
+      {:ok, app} ->
+        Logger.debug("#{__MODULE__} fetched shopify app #{app.name}")
+        generate_authorization_uri(conn, app)
+
+      _ ->
+        Logger.error("#{__MODULE__} unable to fetch shopify app #{ConnHelpers.app_name(conn)}")
+        {:error, "unable to fetch shopify app"}
+    end
+  end
+
+  defp generate_authorization_uri(conn, app) do
+    Logger.debug("#{__MODULE__} fetched shopify app #{app.name}")
+    domain = ConnHelpers.shop_domain(conn)
+
+    case post_auth_redirect_uri(app, domain) do
+      {:ok, redirect_uri} ->
+        auth_uri = ShopifyAuthRequest.generate_auth_uri(app, domain, redirect_uri)
+        {:ok, auth_uri}
+
+      {:error, _resp} ->
+        msg =
+          "Unable to find a configured authorization redirect URI. " <>
+            "Please configure an authorization redirect URI using the ShopifyAPI.Authorizer.uri " <>
+            "Configuration directive, or set up the ShopifyAPI.App run_uri callback. See the " <>
+            "ShopifyAPI readme for more information."
+
+        Logger.error(msg)
+        raise msg
+    end
+  end
+
+  defp generate_install_uri(%Plug.Conn{} = conn) do
+    case ConnHelpers.fetch_shopify_app(conn) do
+      {:ok, app} ->
+        Logger.debug("#{__MODULE__} fetched shopify app #{app.name}")
+        generate_install_uri(conn, app)
+
+      _ ->
+        Logger.error("#{__MODULE__} unable to fetch shopify app #{ConnHelpers.app_name(conn)}")
+        {:error, "unable to fetch shopify app"}
+    end
+  end
+
+  defp generate_install_uri(conn, app) do
+    domain = ConnHelpers.shop_domain(conn)
+
+    case post_install_redirect_uri(app, domain) do
+      {:ok, redirect_uri} ->
+        auth_uri = ShopifyAuthRequest.generate_auth_uri(app, domain, redirect_uri)
+        {:ok, auth_uri}
+
+      {:error, _resp} ->
+        msg =
+          "Unable to find a configured installation redirect URI. " <>
+            "Please configure an installation redirect URI using the ShopifyAPI.Authorizer.uri " <>
+            "Configuration directive, or set up the ShopifyAPI.App install_uri callback. See the " <>
+            "ShopifyAPI readme for more information."
+
+        Logger.error(msg)
+        raise msg
+    end
+  end
+
+  @spec post_auth_redirect_uri(ShopifyAPI.App.t(), binary()) ::
+          {:ok, binary()} | {:error, binary()}
+  defp post_auth_redirect_uri(app, domain) do
+    conf = Application.get_env(:shopify_api, ShopifyAPI.Authorizer)
+    base_uri = if is_list(conf), do: conf[:uri], else: nil
+
+    case base_uri do
+      nil ->
+        generate_auth_redirect_from_app(app, domain)
+
+      base ->
+        generate_redirect_from_uri(base, "run", app.name)
+    end
+  end
+
+  @spec post_install_redirect_uri(ShopifyAPI.App.t(), binary()) ::
+          {:ok, binary()} | {:error, binary()}
+  defp post_install_redirect_uri(app, domain) do
+    conf = Application.get_env(:shopify_api, ShopifyAPI.Authorizer)
+    base_uri = if is_list(conf), do: conf[:uri], else: nil
+
+    case base_uri do
+      nil ->
+        generate_install_redirect_from_app(app, domain)
+
+      base_uri ->
+        generate_redirect_from_uri(base_uri, "install", app.name)
+    end
+  end
+
+  defp generate_redirect_from_uri(base, type, app_name) do
+    case base do
+      b when is_binary(b) ->
+        redirect = "#{base}/#{type}/#{app_name}"
+        Logger.debug("#{__MODULE__} uri configured. using #{redirect} for redirect uri")
+        {:ok, redirect}
+
+      _ ->
+        {:error, "invalid base. Cannot generate redirect."}
+    end
+  end
+
+  defp generate_auth_redirect_from_app(app, domain) do
+    case Config.lookup(ShopifyAPI.App, :run_uri) do
+      redirect when is_binary(redirect) ->
+        Logger.debug("#{__MODULE__} generated authorization uri for #{domain} = #{redirect}")
+        {:ok, redirect}
+
+      nil ->
+        app.auth_redirect_uri
+
+      _ ->
+        {:error, "No App auth redirection uri defined"}
+    end
+  end
+
+  defp generate_install_redirect_from_app(app, domain) do
+    case Config.lookup(ShopifyAPI.App, :install_uri) do
+      redirect when is_binary(redirect) ->
+        Logger.debug("#{__MODULE__} generated authorization uri for #{domain} = #{redirect}")
+        {:ok, redirect}
+
+      nil ->
+        app.auth_redirect_uri
+
+      _ ->
+        {:error, "No App install redirection uri defined"}
+    end
+  end
+
+  @spec install_app(Plug.Conn.t()) :: Plug.Conn.t()
+  def install_app(conn) do
+    case authorize_shop(conn) do
+      {:ok, _resp} ->
+        run_post_install(conn)
+
+      {:error, _msg} ->
+        halt_install(conn)
+    end
+  end
+
+  @spec run_app(Plug.Conn.t()) :: Plug.Conn.t()
+  def run_app(conn) do
+    case authorize_shop(conn) do
+      {:ok, _resp} ->
+        run_post_auth(conn)
+
+      {:error, _msg} ->
+        halt_install(conn)
+    end
+  end
+
+  @spec authorize_shop(Plug.Conn.t()) :: {:ok, any()} | {:error, any()}
+  def authorize_shop(conn) do
+    case ConnHelpers.fetch_shopify_app(conn) do
+      {:ok, app} ->
+        update_token_for(conn, app)
+
+      _ ->
+        Logger.debug("#{__MODULE__}  app #{ConnHelpers.app_name(conn)} not found")
+        {:error, "unable to fetch app"}
+    end
+  end
+
+  defp run_post_auth(conn) do
+    case Config.lookup(__MODULE__, :run_app) do
+      {module, function} -> apply(module, function, [conn])
+      {module, function, _args} -> apply(module, function, [conn])
+      _ -> render_authenticated_response(conn)
+    end
+  end
+
+  defp run_post_install(conn) do
+    case Config.lookup(__MODULE__, :post_install) do
+      {module, function} -> apply(module, function, [conn])
+      {module, function, _args} -> apply(module, function, [conn])
+      _ -> render_installed_response(conn)
+    end
+  end
+
+  defp update_token_for(conn, app) do
+    if valid_auth_request?(conn, app) do
+      Logger.debug("#{__MODULE__} Authorized #{ConnHelpers.shop_domain(conn)}")
+      config_auth_token(conn, app)
+    else
+      Logger.debug("#{__MODULE__} invalid request for #{ConnHelpers.shop_domain(conn)}. halting.")
+      {:error, "invalid auth request received"}
+    end
+  end
+
+  defp valid_auth_request?(conn, app) do
+    nonce_verified = ConnHelpers.verify_nonce(app, conn.query_params)
+    params_verified = ConnHelpers.verify_params_with_hmac(app, conn.query_params)
+    shop_name_verified = ConnHelpers.verify_shop_name(ShopifyAPI.ConnHelpers.shop_domain(conn))
+
+    Logger.debug(
+      "request: nonce: #{nonce_verified} params: #{params_verified} " <>
+        "shop_name: #{shop_name_verified} " <>
+        "shop domain: #{ShopifyAPI.ConnHelpers.shop_domain(conn)}"
+    )
+
+    nonce_verified && params_verified && shop_name_verified
+  end
+
+  defp config_auth_token(conn, app) do
+    case request_permanent_token(conn, app) do
+      {:ok, auth_token} ->
+        save_auth_token(auth_token)
+        save_shop(conn)
+        run_shop_post_install_callback(auth_token)
+        {:ok, "authorized"}
+
+      {:error, resp} ->
+        {:error, "unable to fetch auth_token #{inspect(resp)}"}
+    end
+  end
+
+  defp save_auth_token(%AuthToken{} = token) do
+    AuthTokenServer.set(token)
+  end
+
+  defp save_shop(conn) do
+    ShopServer.set(%Shop{domain: ConnHelpers.shop_domain(conn)})
+  end
+
+  defp run_shop_post_install_callback(%AuthToken{} = auth_token) do
+    Shop.post_install(auth_token)
+  end
+
+  defp request_permanent_token(conn, app) do
+    shop_domain = ConnHelpers.shop_domain(conn)
+    app_name = ConnHelpers.app_name(conn)
+    auth_code = ConnHelpers.auth_code(conn)
+    timestamp = String.to_integer(conn.query_params["timestamp"])
+
+    Logger.debug(
+      "#{__MODULE__} requesting permanent token shop: #{shop_domain}  app: #{app_name}"
+    )
+
+    app
+    |> App.fetch_token(shop_domain, auth_code)
+    |> case do
+      {:ok, token} ->
+        Logger.debug(
+          "#{__MODULE__} successfully fetched permanent token " <>
+            "shop: #{shop_domain} app: #{app_name}"
+        )
+
+        {:ok,
+         %AuthToken{
+           app_name: app_name,
+           shop_name: shop_domain,
+           code: auth_code,
+           timestamp: timestamp,
+           token: token
+         }}
+
+      msg ->
+        Logger.error(
+          "#{__MODULE__} unable to fetch permanent token shop: #{shop_domain} " <>
+            "app: #{app_name} #{inspect(msg)}"
+        )
+
+        {:error, "unable to fetch token"}
+    end
+  end
+
+  defp render_authenticated_response(conn) do
+    shop_domain = ConnHelpers.shop_domain(conn)
+    Logger.debug("#{__MODULE__} rendering authenticated response for #{shop_domain}")
+
+    conn
+    |> Conn.resp(
+      200,
+      "Authenticated. <p>Update <ul><pre>config :shopify_api, ShopifyAPI.Authorizer, " <>
+        "run_app: {MyAppWeb.AppController, :run_app} </pre></ul> to configure. See ShopifyAPI " <>
+        "README for more information</p>"
+    )
+    |> Conn.halt()
+  end
+
+  defp render_installed_response(conn) do
+    shop_domain = ConnHelpers.shop_domain(conn)
+    Logger.debug("#{__MODULE__} rendering authenticated response for #{shop_domain}")
+
+    conn
+    |> Conn.resp(
+      200,
+      "Authenticated. <p>Update <ul><pre>config :shopify_api, ShopifyAPI.Authorizer, " <>
+        "post_install: {MyAppWeb.AppController, :post_install} </pre></ul> to configure. See " <>
+        "ShopifyAPI README for more information</p>"
+    )
+    |> Conn.halt()
+  end
+
+  defp redirect_to_shopify_auth(conn, uri) do
+    Logger.debug(
+      "#{__MODULE__} redirecting to shopify to complete auth for " <>
+        "#{ConnHelpers.shop_domain(conn)} to #{uri}"
+    )
+
+    conn
+    |> Conn.put_resp_header("location", uri)
+    |> Conn.resp(unquote(302), "You are being redirected.")
+    |> Conn.halt()
+  end
+
+  defp halt_install(conn) do
+    shop_domain = ConnHelpers.shop_domain(conn)
+    Logger.info("#{__MODULE__} halting installation of #{shop_domain}")
+
+    conn
+    |> Conn.resp(404, "Not Found.")
+    |> Conn.halt()
+  end
+end

--- a/lib/shopify_api/conn_helpers.ex
+++ b/lib/shopify_api/conn_helpers.ex
@@ -99,12 +99,22 @@ defmodule ShopifyAPI.ConnHelpers do
   @doc false
   @spec verify_params_with_hmac(App.t(), map()) :: boolean()
   def verify_params_with_hmac(%App{client_secret: secret}, params) do
-    params["hmac"] ==
-      params
-      |> Enum.reject(fn {key, _} -> key == "hmac" or key == "signature" end)
-      |> Enum.sort_by(&elem(&1, 0))
-      |> Enum.map(fn {key, value} -> key <> "=" <> value end)
-      |> Enum.join("&")
-      |> Security.base16_sha256_hmac(secret)
+    hmac = build_hmac_from_params(params, secret)
+    params["hmac"] == hmac
+  end
+
+  def build_hmac_from_params(params, secret) do
+    params
+    |> Enum.reject(fn {key, _} -> "#{key}" == "hmac" or "#{key}" == "signature" end)
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(fn {key, value} -> "#{key}" <> "=" <> "#{value}" end)
+    |> Enum.join("&")
+    |> Security.base16_sha256_hmac(secret)
+  end
+
+  @doc false
+
+  def verify_shop_name(name) do
+    String.match?("#{name}", ~r/^[a-zA-Z0-9][a-zA-Z0-9\-]*\.myshopify\.com[\/]?/)
   end
 end

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -60,17 +60,26 @@ defmodule ShopifyAPI.GraphQL do
     actual_cost =
       metadata
       |> get_in(["cost", "actualQueryCost"])
-      |> Kernel.trunc()
+      |> case do
+        nil -> nil
+        val -> Kernel.trunc(val)
+      end
 
     currently_available =
       metadata
       |> get_in(["cost", "throttleStatus", "currentlyAvailable"])
-      |> Kernel.trunc()
+      |> case do
+        nil -> nil
+        val -> Kernel.trunc(val)
+      end
 
     maximum_available =
       metadata
       |> get_in(["cost", "throttleStatus", "maximumAvailable"])
-      |> Kernel.trunc()
+      |> case do
+        nil -> nil
+        val -> Kernel.trunc(val)
+      end
 
     rate_limit(actual_cost, currently_available, maximum_available)
   end

--- a/lib/shopify_api/router.ex
+++ b/lib/shopify_api/router.ex
@@ -1,83 +1,188 @@
 defmodule ShopifyAPI.Router do
   use Plug.Router
-  require Logger
 
-  alias Plug.Conn
-  alias ShopifyAPI.{App, AuthToken, AuthTokenServer, ConnHelpers}
-  alias ShopifyAPI.Shop
+  alias ShopifyAPI.{Authorizer}
 
   plug(:match)
   plug(:dispatch)
 
+  #  `/start/:app`
+  #   The first step in the OAuth process... All requests start here.
+  #
+  #   In this portion of the request, we ensure the request is valid (to the best of our
+  #   abilities) and then redirect the request back to Shopify so that they can finalize the
+  #   OAuth permission flow.
+  #
+  #   As a part of this, we provide Shopify a redirect url to come back to based on whether
+  #   this is the first time we're receiving a request for the shop, or if this is a request for a
+  #   shop whose credentials are already installed.
+  #
+  #   Once Shopify has authorized the request, they use the redirect we've provided to make a
+  #   request to the appropriate endpoint (either /install/:app or /run/:app based on shop state
+  #   in our system).
+  #
+  #   From there, we handle that secondary request according to the rules for that endpoint.
+  #
+  #   ## Configuration
+  #    Shopify will need to have a way to reach your app during the OAuth process & so you'll
+  #    need to let Shopify know how to do this. Unfortunately, this is not something that can be
+  #    handled dynamically or via introspection; this needs to be set up statically in a couple of
+  #    places: both in the Shopify Settings for your app and in the ShopifyAPI library settings.
+  #
+  #    There's two parts to getting this route set up.
+  #
+  #    1. You'll need to set up the full url to the location of the ShopifyAPI /start/:app
+  #        endpoint in the `App URL` configuration text field in the `URLs` section of the
+  #        Shopify Partners `Apps` interface.
+  #    2. The ShopifyAPI library will also need to know where it lives on the Internet. This will
+  #        require letting ShopifyAPI know the web URL that it has been mounted to in your
+  #        Phoenix routes.
+  #
+  #    For example, if we had our app named `best_app_evah` added to ShopifyAPI and  hosted
+  #   at `https://muh-app.ngrok.io/` and we configured our Phoenix routes to forward requests
+  #   going to `/shop` to the ShopifyAPI App router, then we'd set `App URL`
+  #   in the Shopify App Setup interface to be `https://muh-app.ngrok.io/shop/start/best_app_evah`
+  #   and we'd configure our Elixir app to look something like:
+  #
+  #    In order to let ShopifyAPI know where it lives, we use the ShopifyApi.Authorizer uri
+  #    configuration directive.
+  #
+  #  ### Example
+  #  ```elixir
+  #    config :shopify_api, ShopifyAPI.Authorizer,
+  #         uri: "https://muh-app.ngrok.io/app"
+  #  ```
+  #
+  #  *note -- this Elixir app configuration needs only happen once. It will be available for all
+  #  apps once it is set in your application; however, each application you install will need to
+  #  have it's analog Shopify App configuration updated to reflect where ShopifyAPI is available
+  #  on the Internet.
+  get "/start/:app" do
+    Authorizer.authorize_request(conn)
+  end
+
+  #  `/install/:app`
+  #   Install the Shop credentials into the app.
+  #
+  #   This is the path that Shopify will hit once the user authorizes the app in the Shopify app
+  #   interface. This is the route used when ShopifyAPI library installs the shop credentials
+  #   locally.
+  #
+  #   This should only be used once -- at the time of shop credential installation. Once the shop
+  #    credentials have been installed, this path should no longer be used, but rather, the
+  #    /run/:app path will be used after Shopify OAuth process has returned control to your
+  #    app.
+  #
+  #   ## Configuration
+  #
+  #    This route requires analog configuration in the Shopify App setup interface under the
+  #    `URLs` section. The full URL to the `/install/:app` endpoint will need to be added to
+  #     the list of `Allowed Redirection URL(s)`
+  #
+  #   For example, if we had our app named `best_app_evah` added to ShopifyAPI and  hosted
+  #   at `https://muh-app.ngrok.io/` and we configured our Phoenix routes to forward requests
+  #   going to `/shop` to the ShopifyAPI App router, then we'd add
+  #   `https://muh-app.ngrok.io/shop/install/best_app_evah` to the list of `Allowed Redirection
+  #   URL(s)` in the Shopify App Setup interface.
+  #
+  #   In addition to setting up the `/install/:app` endpoint as a valid redirection URL, you'll
+  #   likely want to configure some behavior to occur after the installation has completed.
+  #   ShopifyAPI includes a hook to allow you to customize the behavior of the library once
+  #   it has completed the installation process.
+  #
+  #   You can customize the behavior that occurs after the Shop credentials are installed by
+  #   setting the `ShopifyApi.Authorizer post_install` callback hook in your application
+  #   configuration.
+  #
+  #   ### Example
+  #   For example, if you wanted to show a specific page after install completes, set your
+  #   application config with something like this:
+  #
+  #  ```elixir
+  #  config :shopify_api, ShopifyAPI.Authorizer,
+  #         post_install: {MuhAppWeb.AppController, :do_post_install}
+  #  ```
+  #
+  #  In this example, we've let ShopifyAPI know that we want to run the `do_post_install`
+  #  function in the `MuhAppWeb.AppController` module once the installation has completed.
+  #
+  #  The function you point to should be able to handle a Plug.Conn connection as its only
+  #  argument. Normally, this would be handled in a Phoenix controller in your Phoenix app.
+  #
+  #  The function definition for the configuration above might look something like:
+  #
+  #  ```elixir
+  #  defmodule MuhAppWeb.AppController do
+  #    def do_post_install(conn) do
+  #      conn
+  #      |> put_view(MuhAppWeb.AppView)
+  #      |> render("post_install.html")
+  #      |> halt()
+  #      end
+  #    end
+  #  ```
+  #  *note -- this Elixir app configuration needs only happen once. It will be available for all
+  #  apps once it is set in your application; however, each application you install will need to
+  #  have it's analog Shopify App configuration updated to reflect where ShopifyAPI is available
+  #  on the Internet.
   get "/install/:app" do
-    install_app(conn)
+    Authorizer.install_app(conn)
   end
 
-  get "/install" do
-    install_app(conn)
-  end
-
-  # Shopify Callback on App authorization
-  get "/authorized/:app" do
-    Logger.info("Authorized #{ConnHelpers.shop_domain(conn)}")
-
-    with {:ok, app} <- ConnHelpers.fetch_shopify_app(conn),
-         true <- ConnHelpers.verify_nonce(app, conn.query_params),
-         true <- ConnHelpers.verify_params_with_hmac(app, conn.query_params),
-         {:ok, auth_token} <- request_auth_token(conn, app) do
-      Shop.post_install(auth_token)
-      AuthTokenServer.set(auth_token)
-
-      conn
-      |> Conn.resp(200, "Authenticated.")
-      |> Conn.halt()
-    else
-      res ->
-        Logger.info("#{__MODULE__} failed authorized with: #{inspect(res)}")
-
-        conn
-        |> Conn.resp(404, "Not Found.")
-        |> Conn.halt()
-    end
-  end
-
-  defp request_auth_token(conn, app) do
-    app
-    |> App.fetch_token(ConnHelpers.shop_domain(conn), ConnHelpers.auth_code(conn))
-    |> case do
-      {:ok, token} ->
-        {:ok,
-         %AuthToken{
-           app_name: ConnHelpers.app_name(conn),
-           shop_name: ConnHelpers.shop_domain(conn),
-           code: ConnHelpers.auth_code(conn),
-           timestamp: String.to_integer(conn.query_params["timestamp"]),
-           token: token
-         }}
-
-      _msg ->
-        {:error, "unable to fetch token"}
-    end
-  end
-
-  defp install_app(conn) do
-    conn
-    |> ConnHelpers.fetch_shopify_app()
-    |> case do
-      {:ok, app} ->
-        install_url = App.install_url(app, ConnHelpers.shop_domain(conn))
-
-        conn
-        |> Conn.put_resp_header("location", install_url)
-        |> Conn.resp(unquote(302), "You are being redirected.")
-        |> Conn.halt()
-
-      res ->
-        Logger.info("#{__MODULE__} failed install with: #{res}")
-
-        conn
-        |> Conn.resp(404, "Not Found.")
-        |> Conn.halt()
-    end
+  #  `/run/:app`
+  #   Load and run the app.
+  #
+  #  This is the path that Shopify will use for normal day-to-day usage of your app.
+  #
+  #   ## Configuration
+  #
+  #    This route requires analog configuration in the Shopify App setup interface under the
+  #    `URLs` section. The full URL to the `/run/:app` endpoint will need to be added to the
+  #    list of `Allowed Redirection URL(s)`
+  #
+  #   For example, if we had our app named `best_app_evah` added to ShopifyAPI and  hosted
+  #   at `https://muh-app.ngrok.io/` and we configured our Phoenix routes to forward requests
+  #   going to `/shop` to the ShopifyAPI App router, then we'd add
+  #   `https://muh-app.ngrok.io/shop/run/best_app_evah` to the list of `Allowed Redirection
+  #   URL(s)` in the Shopify App Setup interface.
+  #
+  #   In addition to setting up the `/run/:app` endpoint as a valid redirection URL, you'll likely
+  #    want to configure some behavior to occur after authorization has completed and Shopify
+  #    returns control of the OAuth flow to your app. ShopifyAPI includes some hooks to allow
+  #    you to customize the behavior of the library once it has completed the authorization
+  #    process.
+  #
+  #   You can customize the behavior that occurs after the request has been authorized by
+  #   setting the `ShopifyApi.Authorizer run_app` callback hook in your application configuration.
+  #
+  #   ### Example
+  #   For example, to load up the application once auth has completed, set your application
+  #   config with something like this:
+  #
+  #  ```elixir
+  #  config :shopify_api, ShopifyAPI.Authorizer,
+  #         run_app: {MuhAppWeb.AppController, :run_my_app}
+  #  ```
+  #
+  #  In this example, we've let ShopifyAPI know that we want to run the `run_my_app`
+  #  function in the `MuhAppWeb.AppController` module once authorization has completed.
+  #
+  #  The function you point to should be able to handle a Plug.Conn connection as its only
+  #  argument. Normally, this would be handled in a Phoenix controller in your Phoenix app.
+  #
+  #  The function definition for the configuration above might look something like:
+  #
+  #  ```elixir
+  #  defmodule MuhAppWeb.AppController do
+  #    def run_my_app(conn) do
+  #      conn
+  #      |> put_view(MuhAppWeb.AppView)
+  #      |> render("my_app.html")
+  #      |> halt()
+  #      end
+  #    end
+  #  ```
+  get "/run/:app" do
+    Authorizer.run_app(conn)
   end
 end

--- a/lib/shopify_api/shop.ex
+++ b/lib/shopify_api/shop.ex
@@ -25,4 +25,8 @@ defmodule ShopifyAPI.Shop do
 
   defp call_post_install({module, function, _}, token), do: apply(module, function, [token])
   defp call_post_install(nil, _token), do: nil
+
+  def shopify_url_for(shop_name: shop_name) do
+    "#{ShopifyAPI.transport()}#{shop_name}"
+  end
 end

--- a/lib/shopify_api/shopify_auth_request.ex
+++ b/lib/shopify_api/shopify_auth_request.ex
@@ -1,0 +1,54 @@
+defmodule ShopifyAPI.ShopifyAuthRequest do
+  @moduledoc """
+    ShopifyAuthRequest.post/3 contains logic to request AuthTokens from Shopify given an App,
+    Shop domain, and the auth code from the App install.
+  """
+  require Logger
+
+  alias ShopifyAPI.{App, JSONSerializer}
+  @headers [{"Content-Type", "application/json"}]
+
+  defp access_token_url(domain) do
+    d = if ShopifyAPI.bypass_host(), do: ShopifyAPI.bypass_host(), else: domain
+    "#{ShopifyAPI.transport()}#{d}/admin/oauth/access_token"
+  end
+
+  @spec post(App.t(), String.t(), String.t()) :: {:ok, any()} | {:error, any()}
+  def post(%App{} = app, domain, auth_code) do
+    http_body = %{
+      client_id: app.client_id,
+      client_secret: app.client_secret,
+      code: auth_code
+    }
+
+    Logger.debug(fn -> "#{__MODULE__} requesting token from #{access_token_url(domain)}" end)
+    encoded_body = JSONSerializer.encode!(http_body)
+    HTTPoison.post(access_token_url(domain), encoded_body, @headers)
+  end
+
+  @doc """
+    Generates the install URL for an App and a Shop.
+  """
+  @spec install_uri(App.t(), String.t()) :: String.t()
+  def install_uri(%App{} = app, domain) when is_binary(domain) do
+    redirect_uri = App.auth_install_uri(app)
+    generate_auth_uri(app, domain, redirect_uri)
+  end
+
+  @spec auth_uri(App.t(), String.t()) :: String.t()
+  def auth_uri(%App{} = app, domain) when is_binary(domain) do
+    redirect_uri = App.auth_redirect_uri(app)
+    generate_auth_uri(app, domain, redirect_uri)
+  end
+
+  def generate_auth_uri(app, domain, redirect_uri) do
+    query_params = [
+      client_id: app.client_id,
+      scope: app.scope,
+      redirect_uri: redirect_uri,
+      state: app.nonce
+    ]
+
+    "https://#{domain}/admin/oauth/authorize?#{URI.encode_query(query_params)}"
+  end
+end

--- a/test/shopify_api/router_test.exs
+++ b/test/shopify_api/router_test.exs
@@ -3,8 +3,8 @@ defmodule Test.ShopifyAPI.RouterTest do
   use Plug.Test
 
   alias ShopifyAPI.{App, Shop}
-  alias ShopifyAPI.{AppServer, AuthTokenServer, ShopServer}
-  alias ShopifyAPI.{JSONSerializer, Router, Security}
+  alias ShopifyAPI.{AppServer, AuthTokenServer, ConnHelpers, ShopServer}
+  alias ShopifyAPI.{JSONSerializer, Router}
 
   alias Plug.{Conn, Parsers}
 
@@ -15,11 +15,13 @@ defmodule Test.ShopifyAPI.RouterTest do
     Parsers.call(conn, Parsers.init(opts))
   end
 
+  @code "testing"
   @app_name "test"
-  @client_secret "test"
   @nonce "testing"
   @redirect_uri "example.com"
-  @shop_domain "shop.example.com"
+  @shop_domain "shop.myshopify.com"
+  @timestamp "1234"
+  @client_secret "5fd0b04756f115ecb0820cabc1779a2286e32b66501936c9d7103907bcba9ef1"
 
   setup_all do
     AppServer.set(@app_name, %App{
@@ -31,14 +33,21 @@ defmodule Test.ShopifyAPI.RouterTest do
     })
 
     ShopServer.set(%Shop{domain: @shop_domain})
+
+    Application.put_env(:shopify_api, ShopifyAPI.Authorizer,
+      uri: "https://example.com/app",
+      post_install: {PostAuthModule, :post_install},
+      run_app: {PostAuthModule, :run_app}
+    )
+
     :ok
   end
 
-  describe "/install" do
+  describe "/start/:app" do
     test "with a valid app it redirects" do
       conn =
         :get
-        |> conn("/install?app=#{@app_name}&shop=#{@shop_domain}")
+        |> conn("/start/#{@app_name}?#{add_hmac_to_params()}")
         |> parse()
         |> Router.call(%{})
 
@@ -53,7 +62,7 @@ defmodule Test.ShopifyAPI.RouterTest do
     test "without a valid app it errors" do
       conn =
         :get
-        |> conn("/install?app=not-an-app&shop=#{@shop_domain}")
+        |> conn("/start/not-an-app?#{add_hmac_to_params(%{app_name: "not-an-app"})}")
         |> parse()
         |> Router.call(%{})
 
@@ -61,23 +70,25 @@ defmodule Test.ShopifyAPI.RouterTest do
     end
   end
 
-  describe "/authorized" do
+  describe "/install/:app" do
     @code "testing"
     @token %{access_token: "test-token"}
 
     setup _contxt do
-      bypass = Bypass.open()
-      shop_domain = "localhost:#{bypass.port}"
-      ShopServer.set(%Shop{domain: shop_domain})
+      bypass = Bypass.open(port: Application.get_env(:shopify_api, :bypass_port))
+      auth_server = "#{Application.get_env(:shopify_api, :bypass_host)}:#{bypass.port}"
+      ShopServer.set(%Shop{domain: @shop_domain})
 
-      {:ok, %{bypass: bypass, shop_domain: shop_domain}}
+      {:ok, %{bypass: bypass, shop_domain: @shop_domain, auth_server: auth_server}}
     end
 
     test "fails with invalid hmac", %{bypass: _bypass, shop_domain: shop_domain} do
       conn =
         :get
         |> conn(
-          "/authorized/#{@app_name}?shop=#{shop_domain}&code=#{@code}&timestamp=1234&hmac=invalid"
+          "/install/#{@app_name}?#{
+            add_hmac_to_params(%{shop_domain: shop_domain, hmac: "invalid"})
+          }"
         )
         |> parse()
         |> Router.call(%{})
@@ -86,7 +97,7 @@ defmodule Test.ShopifyAPI.RouterTest do
     end
 
     test "fetches the token", %{bypass: bypass, shop_domain: shop_domain} do
-      Bypass.expect_once(bypass, "POST", "/admin/oauth/access_token", fn conn ->
+      Bypass.expect(bypass, fn conn ->
         {:ok, body} = JSONSerializer.encode(@token)
         Conn.resp(conn, 200, body)
       end)
@@ -94,8 +105,8 @@ defmodule Test.ShopifyAPI.RouterTest do
       conn =
         :get
         |> conn(
-          "/authorized/#{@app_name}?" <>
-            add_hmac_to_params("code=#{@code}&shop=#{shop_domain}&state=#{@nonce}&timestamp=1234")
+          "/install/#{@app_name}?" <>
+            add_hmac_to_params(%{shop_domain: shop_domain})
         )
         |> parse()
         |> Router.call(%{})
@@ -109,8 +120,8 @@ defmodule Test.ShopifyAPI.RouterTest do
       conn =
         :get
         |> conn(
-          "/authorized/invalid-app?" <>
-            add_hmac_to_params("code=#{@code}&shop=#{shop_domain}&state=invalid&timestamp=1234")
+          "/install/#{@app_name}?" <>
+            add_hmac_to_params(%{shop_domain: shop_domain, nonce: "invalid"})
         )
         |> parse()
         |> Router.call(%{})
@@ -122,8 +133,8 @@ defmodule Test.ShopifyAPI.RouterTest do
       conn =
         :get
         |> conn(
-          "/authorized/invalid-app?" <>
-            add_hmac_to_params("code=#{@code}&shop=#{shop_domain}&state=#{@nonce}&timestamp=1234")
+          "/install/invalid-app?" <>
+            add_hmac_to_params(%{shop_domain: shop_domain})
         )
         |> parse()
         |> Router.call(%{})
@@ -135,8 +146,32 @@ defmodule Test.ShopifyAPI.RouterTest do
       conn =
         :get
         |> conn(
-          "/authorized/#{@app_name}?" <>
-            add_hmac_to_params("code=#{@code}&shop=invalid-shop&state=#{@nonce}&timestamp=1234")
+          "/install/#{@app_name}?" <>
+            add_hmac_to_params(%{shop_domain: "invalid-shop"})
+        )
+        |> parse()
+        |> Router.call(%{})
+
+      assert conn.status == 404
+    end
+  end
+
+  describe "/run/:app" do
+    @code "testing"
+
+    setup _contxt do
+      bypass = Bypass.open(port: Application.get_env(:shopify_api, :bypass_port))
+      auth_server = "#{Application.get_env(:shopify_api, :bypass_host)}:#{bypass.port}"
+      ShopServer.set(%Shop{domain: @shop_domain})
+
+      {:ok, %{bypass: bypass, shop_domain: @shop_domain, auth_server: auth_server}}
+    end
+
+    test "fails with invalid hmac", %{bypass: _bypass, shop_domain: shop_domain} do
+      conn =
+        :get
+        |> conn(
+          "/run/#{@app_name}?#{add_hmac_to_params(%{shop_domain: shop_domain, hmac: "invalid"})}"
         )
         |> parse()
         |> Router.call(%{})
@@ -144,8 +179,81 @@ defmodule Test.ShopifyAPI.RouterTest do
       assert conn.status == 404
     end
 
-    def add_hmac_to_params(params) do
-      params <> "&hmac=" <> Security.base16_sha256_hmac(params, @client_secret)
+    test "fails without a valid nonce", %{bypass: _bypass, shop_domain: shop_domain} do
+      conn =
+        :get
+        |> conn(
+          "/run/#{@app_name}?" <>
+            add_hmac_to_params(%{shop_domain: shop_domain, nonce: "invalid"})
+        )
+        |> parse()
+        |> Router.call(%{})
+
+      assert conn.status == 404
     end
+
+    test "fails without a valid app", %{bypass: _bypass, shop_domain: shop_domain} do
+      conn =
+        :get
+        |> conn(
+          "/run/invalid-app?" <>
+            add_hmac_to_params(%{shop_domain: shop_domain})
+        )
+        |> parse()
+        |> Router.call(%{})
+
+      assert conn.status == 404
+    end
+
+    test "fails without a valid shop", %{bypass: _bypass} do
+      conn =
+        :get
+        |> conn(
+          "/run/#{@app_name}?" <>
+            add_hmac_to_params(%{shop_domain: "invalid-shop"})
+        )
+        |> parse()
+        |> Router.call(%{})
+
+      assert conn.status == 404
+    end
+  end
+
+  def add_hmac_to_params(params \\ %{}) do
+    t = params[:timestamp] || @timestamp
+    a = params[:app_name] || @app_name
+    d = params[:shop_domain] || @shop_domain
+    n = params[:nonce] || @nonce
+    c = params[:code] || @code
+    s = params[:secret] || @client_secret
+
+    h =
+      params[:hmac] ||
+        ConnHelpers.build_hmac_from_params(
+          %{
+            "timestamp" => t,
+            "app" => a,
+            "shop" => d,
+            "state" => n,
+            "code" => c
+          },
+          s
+        )
+
+    "timestamp=#{t}&app=#{a}&shop=#{d}&state=#{n}&code=#{c}&hmac=#{h}"
+  end
+end
+
+defmodule PostAuthModule do
+  def run_app(conn) do
+    conn
+    |> Plug.Conn.resp(200, "Authenticated.")
+    |> Plug.Conn.halt()
+  end
+
+  def post_install(conn) do
+    conn
+    |> Plug.Conn.resp(200, "Authenticated.")
+    |> Plug.Conn.halt()
   end
 end


### PR DESCRIPTION
This modification primarily attempts to make working with the OAuth flow
easier for an integrator. It also fixes the OAuth flow so that there's a
full round trip for both installation and app authorization.

I believe before we were never doing the full round trip for
standard authorization.

Additionally, we've added a couple of hooks that use the ShopifyAPI
module configuration pattern to allow integrators to hook into the auth
flow without needing to understand the nitty-gritty details of how it
works.

But because there is always going to be some amount of manual
configuration required for the app to be installed in the Shopify store
and that necessitates some underlying understanding of how the OAuth
flow works, we've attempted to add some documentation both in the README
as well as in the routes file to help integrators with understanding how
things work.

The modifications in the routes file break what was there before -- the
routes that were defined are no longer valid. I believe that this will
not really be a dealbreaker for most, as I believe that the former
implementation required integrators to have their own self-baked
solution in place.

This modification hopefully makes it easier to integrate the library
into an application authorization flow. It includes addition of callback
hooks dedicated to making authorization more simple and more
explicit.