### PR TITLE
Add A Place For Apps To Store App Specific Data

### DIFF
--- a/lib/shopify_api/app.ex
+++ b/lib/shopify_api/app.ex
@@ -3,13 +3,22 @@ defmodule ShopifyAPI.App do
     ShopifyAPI.App contains logic and a struct for representing a Shopify App.
   """
   @derive {Jason.Encoder,
-           only: [:name, :client_id, :client_secret, :auth_redirect_uri, :nonce, :scope]}
+           only: [
+             :name,
+             :client_id,
+             :client_secret,
+             :auth_redirect_uri,
+             :nonce,
+             :scope,
+             :app_data
+           ]}
   defstruct name: "",
             client_id: "",
             client_secret: "",
             auth_redirect_uri: "",
             nonce: "",
-            scope: ""
+            scope: "",
+            app_data: %{}
 
   @typedoc """
     Type that represents a Shopify App
@@ -20,7 +29,8 @@ defmodule ShopifyAPI.App do
           client_secret: String.t(),
           auth_redirect_uri: String.t(),
           nonce: String.t(),
-          scope: String.t()
+          scope: String.t(),
+          app_data: map()
         }
 
   require Logger

--- a/lib/shopify_api/auth_token.ex
+++ b/lib/shopify_api/auth_token.ex
@@ -1,11 +1,13 @@
 defmodule ShopifyAPI.AuthToken do
-  @derive {Jason.Encoder, only: [:code, :app_name, :shop_name, :token, :timestamp, :plus]}
+  @derive {Jason.Encoder,
+           only: [:code, :app_name, :shop_name, :token, :timestamp, :plus, :app_data]}
   defstruct code: "",
             app_name: "",
             shop_name: "",
             token: "",
             timestamp: 0,
-            plus: false
+            plus: false,
+            app_data: %{}
 
   @typedoc """
       Type that represents a Shopify Auth Token with
@@ -19,7 +21,8 @@ defmodule ShopifyAPI.AuthToken do
           shop_name: String.t(),
           token: String.t(),
           timestamp: 0,
-          plus: boolean()
+          plus: boolean(),
+          app_data: map()
         }
 
   @spec create_key(t()) :: String.t()

--- a/lib/shopify_api/shop.ex
+++ b/lib/shopify_api/shop.ex
@@ -1,8 +1,9 @@
 defmodule ShopifyAPI.Shop do
   alias ShopifyAPI.AuthToken
 
-  @derive {Jason.Encoder, only: [:domain]}
-  defstruct domain: ""
+  @derive {Jason.Encoder, only: [:domain, :app_data]}
+  defstruct domain: "",
+            app_data: %{}
 
   @typedoc """
       Type that represents a Shopify Shop with
@@ -10,7 +11,8 @@ defmodule ShopifyAPI.Shop do
         - domain corresponding to the full URL for the shop
   """
   @type t :: %__MODULE__{
-          domain: String.t()
+          domain: String.t(),
+          app_data: map()
         }
 
   @spec post_install(AuthToken.t()) :: any()


### PR DESCRIPTION
This modification is intended to allow apps that want to store
additional data in the ETS backed data to be able to do so. It's
intended to be flexible enough to cover differing use-cases that apps
may have.