### PR TITLE
noted spelling fix for persistence, fixes #367

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - BREAKING: Remove `ShopifyAPI.REST.Tag` and associated tests
+- BREAKING: Noted spelling fix of persistance to persistence in v 0.10.0
 
 ## 0.11.0
 
@@ -26,6 +27,7 @@
 
 ## 0.10.0
 
+- BREAKING: `AppServer`, `ShopServer`, `AuthTokenServer` configuration had spelling mistake which was corrected, persistance became persistence.
 - BREAKING: Rename `ShopifyAPI.CacheSupervisor` to `ShopifyAPI.Supervisor`.
 - Upgrade `AppServer`, `ShopServer`, and `AuthTokenServer` to use ets-backed caching.
 - Change default Shopify API version to `2020-10`.

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ If you want persisted Apps, Shops, and Tokens add configuration to your function
 ```elixir
 config :shopify_api, ShopifyAPI.AuthTokenServer,
   initializer: {MyApp.AuthToken, :init, []},
-  persistance: {MyApp.AuthToken, :save, []}
+  persistence: {MyApp.AuthToken, :save, []}
 config :shopify_api, ShopifyAPI.AppServer,
   initializer: {MyApp.ShopifyApp, :init, []},
-  persistance: {MyApp.ShopifyApp, :save, []}
+  persistence: {MyApp.ShopifyApp, :save, []}
 config :shopify_api, ShopifyAPI.ShopServer,
   initializer: {MyApp.Shop, :init, []},
-  persistance: {MyApp.Shop, :save, []}
+  persistence: {MyApp.Shop, :save, []}
 ```
 
 ## Installing this app in a Shop


### PR DESCRIPTION
This breaking change was not noted or changed in the README, this notes it and corrects the documentation.