### PR TITLE
Better Bulk.Query.exec/1 error matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - BREAKING: Remove `ShopifyAPI.REST.Tag` and associated tests
 - BREAKING: Noted spelling fix of persistance to persistence in v 0.10.0
+- Fix: match on status code instead of error string when raising custom bulk fetch errors
 
 ## 0.11.0
 

--- a/lib/shopify_api/bulk/query.ex
+++ b/lib/shopify_api/bulk/query.ex
@@ -99,12 +99,12 @@ defmodule ShopifyAPI.Bulk.Query do
     raise(ShopifyAPI.Bulk.InProgressError, "Shop: #{token.shop_name}, bulk id: #{bulk_id}")
   end
 
-  defp raise_error!(%HTTPoison.Response{body: %{"errors" => "Unavailable Shop"}} = msg, token) do
+  defp raise_error!(%HTTPoison.Response{status_code: 423} = msg, token) do
     Telemetry.send(@log_module, token, {:error, :shop_unavailable, msg})
     raise(ShopifyAPI.ShopUnavailableError, "Shop: #{token.shop_name}")
   end
 
-  defp raise_error!(%HTTPoison.Response{body: %{"errors" => "Not Found"}} = msg, token) do
+  defp raise_error!(%HTTPoison.Response{status_code: 404} = msg, token) do
     Telemetry.send(@log_module, token, {:error, :shop_not_found, msg})
     raise(ShopifyAPI.ShopNotFoundError, "Shop: #{token.shop_name}")
   end

--- a/test/shopify_api/bulk/query_test.exs
+++ b/test/shopify_api/bulk/query_test.exs
@@ -126,6 +126,36 @@ defmodule ShopifyAPI.Bulk.QueryTest do
     end
   end
 
+  test "exec/1 with 404 response", %{
+    bypass: bypass,
+    shop: _shop,
+    auth_token: token,
+    options: options
+  } do
+    Bypass.expect(bypass, "POST", @graphql_path, fn conn ->
+      Plug.Conn.resp(conn, 404, Jason.encode!(""))
+    end)
+
+    assert_raise ShopifyAPI.ShopNotFoundError, fn ->
+      Query.exec!(token, "fake_query", options)
+    end
+  end
+
+  test "exec/1 with 423 response", %{
+    bypass: bypass,
+    shop: _shop,
+    auth_token: token,
+    options: options
+  } do
+    Bypass.expect(bypass, "POST", @graphql_path, fn conn ->
+      Plug.Conn.resp(conn, 423, Jason.encode!(""))
+    end)
+
+    assert_raise ShopifyAPI.ShopUnavailableError, fn ->
+      Query.exec!(token, "fake_query", options)
+    end
+  end
+
   @json1 %{"test" => "foo"}
   @json2 %{"test" => "bar fuzz"}
   @json3 %{"test" => "baz\nbuzz"}


### PR DESCRIPTION
Previously matched on a string, and Shopify sends back a variety of error messages.