### PR TITLE
Version bump to v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.12.0
+
 - BREAKING: Remove `ShopifyAPI.REST.Tag` and associated tests
 - BREAKING: Noted spelling fix of persistance to persistence in v 0.10.0
 - Fix: match on status code instead of error string when raising custom bulk fetch errors

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.11.0"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.12.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.11.0"
+  @version "0.12.0"
 
   def project do
     [


### PR DESCRIPTION
- BREAKING: Remove `ShopifyAPI.REST.Tag` and associated tests
- BREAKING: Noted spelling fix of persistance to persistence in v 0.10.0
- Fix: match on status code instead of error string when raising custom bulk fetch errors