### PR TITLE
Version bump to v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.12.1
+
+- Fix: properly handle both 402 and 423s when raising custom bulk fetch errors
+
 ## 0.12.0
 
 - BREAKING: Remove `ShopifyAPI.REST.Tag` and associated tests

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.12.0"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.12.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.12.0"
+  @version "0.12.1"
 
   def project do
     [


### PR DESCRIPTION
- Fix: properly handle both 402 and 423s when raising custom bulk fetch errors
