### PR TITLE
Update recurring charge request args to be uniform

### DIFF
--- a/lib/shopify_api/rest/recurring_application_charge.ex
+++ b/lib/shopify_api/rest/recurring_application_charge.ex
@@ -27,7 +27,7 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
       ) do
     REST.post(auth, "recurring_application_charges.json", recurring_application_charge)
   end
-  
+
   def create(
         %AuthToken{} = auth,
         %{} = recurring_application_charge

--- a/lib/shopify_api/rest/recurring_application_charge.ex
+++ b/lib/shopify_api/rest/recurring_application_charge.ex
@@ -12,14 +12,29 @@ defmodule ShopifyAPI.REST.RecurringApplicationCharge do
 
   ## Example
 
+      iex> ShopifyAPI.REST.RecurringApplicationCharge.create(auth, %{recurring_application_charge: map()})
+      {:ok, %{} = recurring_application_charge}
+
+        or
+
       iex> ShopifyAPI.REST.RecurringApplicationCharge.create(auth, map)
       {:ok, %{} = recurring_application_charge}
+
   """
   def create(
         %AuthToken{} = auth,
         %{recurring_application_charge: %{}} = recurring_application_charge
       ) do
     REST.post(auth, "recurring_application_charges.json", recurring_application_charge)
+  end
+  
+  def create(
+        %AuthToken{} = auth,
+        %{} = recurring_application_charge
+      ) do
+    REST.post(auth, "recurring_application_charges.json", %{
+      recurring_application_charge: recurring_application_charge
+    })
   end
 
   @doc """


### PR DESCRIPTION
This is a simple modification that allows for arguments passed to the create function of the RecurringApplicationCharge REST module to use the same pattern for calls as other functions use. In those cases, the outer map is added by the request logic, so the caller only needs to pass the map representing the data of the struct itself.


There's some failures noted in the build, but those appear CI issues that are outside of the changes made. 

Going to open this up in spite of that to raise visibility into that issue, to make sure I'm not misreading things & to get this simple modification incorporated if everything looks good.

