### PR TITLE
make nonce checking optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix: Nonce check on install when Shopify does not pass a nonce to the endpoint.
+
 ## 0.12.3
 
 - Fix: Allow options to be passed to HTTPoison when making GET requests through `ShopifyAPI.REST`.

--- a/lib/shopify_api/conn_helpers.ex
+++ b/lib/shopify_api/conn_helpers.ex
@@ -92,11 +92,6 @@ defmodule ShopifyAPI.ConnHelpers do
   end
 
   @doc false
-  def verify_nonce(%App{nonce: nonce}, params) do
-    nonce == params["state"]
-  end
-
-  @doc false
   @spec verify_params_with_hmac(App.t(), map()) :: boolean()
   def verify_params_with_hmac(%App{client_secret: secret}, params) do
     params["hmac"] ==


### PR DESCRIPTION
There are many ways the nonce might not be passed to the endpoint during the install, this makes the checking and validation only happen if the nonce was passed in.

Currently if Shopify doesn't pass the nonce in the validation of the redirect will fail and the AuthToken OAuth process will not kick off.