### PR TITLE
bump to 1.12 otp 24 and remove 1.10 from supported

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,6 +33,7 @@ jobs:
         run: mix credo
 
       - name: Check Formatting
+        if: ${{ matrix.elixir != '1.11.4' }}
         run: mix format --check-formatted
 
       - name: Run Tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,8 +9,8 @@ jobs:
 
     strategy:
       matrix:
-        otp: [22.2, 23.2.1]
-        elixir: [1.10.4, 1.11.3]
+        otp: [23.3.4, 24.0.2]
+        elixir: [1.11.4, 1.12.1]
 
     steps:
       - uses: actions/checkout@v2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 23.2.1
-elixir 1.11.3-otp-23
+erlang 24.0.2
+elixir 1.12.1-otp-24

--- a/lib/shopify_api/graphql.ex
+++ b/lib/shopify_api/graphql.ex
@@ -116,9 +116,7 @@ defmodule ShopifyAPI.GraphQL do
           currently_available: currently_available,
           maximum_available: maximum_available
         } ->
-          "#{@log_module} for #{shop}:#{app} received #{status} in #{div(time, 1_000)}ms [cost #{
-            actual_cost
-          } bucket #{currently_available}/#{maximum_available}]"
+          "#{@log_module} for #{shop}:#{app} received #{status} in #{div(time, 1_000)}ms [cost #{actual_cost} bucket #{currently_available}/#{maximum_available}]"
       end
     end)
   end

--- a/lib/shopify_api/rate_limiting/rest_call_limits.ex
+++ b/lib/shopify_api/rate_limiting/rest_call_limits.ex
@@ -7,7 +7,7 @@ defmodule ShopifyAPI.RateLimiting.RESTCallLimits do
   @over_limit_status_code 429
   # API Overlimit error code
   @spec limit_header_or_status_code(any) :: nil | :over_limit
-  def limit_header_or_status_code(%{status_code: @over_limit_status_code()}),
+  def limit_header_or_status_code(%{status_code: @over_limit_status_code}),
     do: :over_limit
 
   def limit_header_or_status_code(%{headers: headers}),

--- a/lib/shopify_api/rest/request.ex
+++ b/lib/shopify_api/rest/request.ex
@@ -183,9 +183,7 @@ defmodule ShopifyAPI.REST.Request do
       module = module_name()
       method = method |> to_string() |> String.upcase()
 
-      "#{module} #{method} #{url} #{app} #{shop} (#{remaining_calls(response)}) [#{
-        div(time, 1_000)
-      }ms]"
+      "#{module} #{method} #{url} #{app} #{shop} (#{remaining_calls(response)}) [#{div(time, 1_000)}ms]"
     end)
   end
 

--- a/lib/shopify_api/rest/usage_charge.ex
+++ b/lib/shopify_api/rest/usage_charge.ex
@@ -43,9 +43,7 @@ defmodule ShopifyAPI.REST.UsageCharge do
       ) do
     REST.get(
       auth,
-      "recurring_application_charges/#{recurring_application_charge_id}/usage_charges/#{
-        usage_charge_id
-      }.json",
+      "recurring_application_charges/#{recurring_application_charge_id}/usage_charges/#{usage_charge_id}.json",
       params,
       Keyword.merge([pagination: :none], options)
     )

--- a/lib/shopify_api/security.ex
+++ b/lib/shopify_api/security.ex
@@ -1,14 +1,21 @@
 defmodule ShopifyAPI.Security do
   def base16_sha256_hmac(text, secret) do
     :sha256
-    |> :crypto.hmac(secret, text)
+    |> hmac(secret, text)
     |> Base.encode16()
     |> String.downcase()
   end
 
   def base64_sha256_hmac(text, secret) do
     :sha256
-    |> :crypto.hmac(secret, text)
+    |> hmac(secret, text)
     |> Base.encode64()
+  end
+
+  # TODO: remove when we require OTP 22
+  if System.otp_release() >= "22" do
+    defp hmac(digest, key, data), do: :crypto.mac(:hmac, digest, key, data)
+  else
+    defp hmac(digest, key, data), do: :crypto.hmac(digest, key, data)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Plug.ShopifyAPI.MixProject do
     [
       app: :shopify_api,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [


### PR DESCRIPTION
Adding Elixir 1.12 and OTP23 to the mix, letting 1.10 and OTP 22 fall off the list.

- bump supported ver to 1.11.
- bump tool versions to latest otp and elixir
- fix removed `:crypto.hmac/3` (OTP24)