### PR TITLE
Cutting ver 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+
+## 0.14.0
+
 - Remove usage of session and session rehydration from AdminAuthenticator plug.
 - Add ShopServer.delete/1
 - Add 401 unauthorized response to Webhook plug


### PR DESCRIPTION
Changes include:
- Remove usage of session and session rehydration from AdminAuthenticator plug.
- Add ShopServer.delete/1
- Add 401 unauthorized response to Webhook plug
- Call webhook handler even when the shop is not in the ShopServer