### PR TITLE
fixed hmac validation of Plug.AdminAuthenticator, now only authenticates when hmac is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - Fix: typo in `REST.UsageCharges.all/4`
+- BREAKING: fixed hmac validation of Plug.AdminAuthenticator, now only authenticates when hmac is present
+- Added the ability to set a default app name for the Plug.AdminAuthenticator
 
 ## 0.14.3
 


### PR DESCRIPTION
If you deploy your entire admin React app in to a directory and  use this plug it will fail on serving other static assets (js/css). It should only authenticate the request on initial iframe load (ie the hmac is present).