### PR TITLE
cutting v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.15.0
+
 - New: ShopifyId struct adds convenience around shopify ids
 - Fix: typo in `REST.UsageCharges.all/4`
 - BREAKING: fixed hmac validation of Plug.AdminAuthenticator, now only authenticates when hmac is present

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.14.3"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.15.0"}
   ]
 end
 ```


### PR DESCRIPTION
- New: ShopifyId struct adds convenience around shopify ids
- Fix: typo in `REST.UsageCharges.all/4`
- BREAKING: fixed hmac validation of Plug.AdminAuthenticator, now only authenticates when hmac is present
- Added the ability to set a default app name for the Plug.AdminAuthenticator