### PR TITLE
check for passed in app name before using last element of path

### DIFF
--- a/lib/shopify_api/plugs/admin_authenticator.ex
+++ b/lib/shopify_api/plugs/admin_authenticator.ex
@@ -48,7 +48,7 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   end
 
   defp do_authentication(conn, options) do
-    with app_name <- conn.params["app"] || List.last(conn.path_info) || options[:app_name],
+    with app_name <- conn.params["app"] || options[:app_name] || List.last(conn.path_info),
          {:ok, app} <- ShopifyAPI.AppServer.get(app_name),
          :ok <- validate_hmac(app, conn.query_params),
          myshopify_domain <- shop_domain_from_conn(conn),
@@ -123,7 +123,7 @@ defmodule ShopifyAPI.Plugs.AdminAuthenticator do
   end
 
   defp install_path(options, conn) do
-    app_name = conn.params["app"] || List.last(conn.path_info) || options[:app_name]
+    app_name = conn.params["app"] || options[:app_name] || List.last(conn.path_info)
 
     options[:shopify_mount_path] <>
       "/install" <>

--- a/lib/shopify_api/plugs/put_shopify_content_headers.ex
+++ b/lib/shopify_api/plugs/put_shopify_content_headers.ex
@@ -8,7 +8,7 @@ defmodule ShopifyAPI.Plugs.PutShopifyContentHeaders do
 
   ```elixir
   pipeline :shop_admin do
-    plug ShopifyAPI.Plugs.AdminAuthenticator, shopify_router_mount: "/shop"
+    plug ShopifyAPI.Plugs.AdminAuthenticator, shopify_mount_path: "/shop"
     plug ShopifyAPI.Plugs.PutShopifyContentHeaders
   end
   ```


### PR DESCRIPTION
The last element of the path would always return something, but if you were trying to use the options[:app_name] it could be an invalid value.