### PR TITLE
adding missing JSON.Encoder for shopifyid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix: Added JSON.Encoder for ShopifyId
+
 ## 0.16.0
 
 - New: bump supported OTP and Elixir ver

--- a/lib/shopify_api/shopify_id.ex
+++ b/lib/shopify_api/shopify_id.ex
@@ -101,6 +101,14 @@ defmodule ShopifyAPI.ShopifyId do
       do: shopify_id |> ShopifyId.stringify() |> Jason.Encode.string(opts)
   end
 
+  # TODO remove if check once JSON is generally available.
+  if Code.ensure_loaded?(JSON) do
+    defimpl JSON.Encoder do
+      def encode(shopify_id, encoder),
+        do: shopify_id |> ShopifyAPI.ShopifyId.stringify() |> JSON.encode!(encoder)
+    end
+  end
+
   ###################
   # Ecto ParameterizedType Callbacks
   #


### PR DESCRIPTION
This is required for any library that starts using the builtin JSON module.