### PR TITLE
cutting v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.16.2
+
 - BREAKING: Reworked Plugs.AdminAuthenticator to use the new JWT Session functions, this breaks the old redirect for exchanging sessions on install
 - New: JWT session token module to handle validation, information extraction, and exchange in to a Online Auth Token.
 - BREAKING: Changes how the AuthShopSessionToken plug works, it now only redirects on failure to find an online token or failure to exchange the session token for an online token.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.16.1"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.16.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.16.1"
+  @version "0.16.2"
 
   def project do
     [


### PR DESCRIPTION
- BREAKING: Reworked Plugs.AdminAuthenticator to use the new JWT Session functions, this breaks the old redirect for exchanging sessions on install
- New: JWT session token module to handle validation, information extraction, and exchange in to a Online Auth Token.
- BREAKING: Changes how the AuthShopSessionToken plug works, it now only redirects on failure to find an online token or failure to exchange the session token for an online token.