### PR TITLE
refactored webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - Fix: 0.16.2 broke the installation path when no JWT was passed along
+- New: Reworked webhook flow, [check readme](README.md#Webhooks) for details on how to use
+- Deprecation: old Plugs.Webhook is being replaced and will be removed eventually
 
 ## 0.16.2
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,3 +2,5 @@ import Config
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
+
+config :shopify_api, :app_name, "shopify_test_app"

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,3 +7,5 @@ config :bypass, adapter: Plug.Adapters.Cowboy2
 config :shopify_api,
   customer_api_secret_keys: ["new_secret", "old_secret"],
   transport: "http"
+
+config :shopify_api, :app_name, "testapp"

--- a/lib/shopify_api/config.ex
+++ b/lib/shopify_api/config.ex
@@ -1,6 +1,5 @@
 defmodule ShopifyAPI.Config do
   @moduledoc false
-
   def lookup(key), do: Application.get_env(:shopify_api, key)
   def lookup(key, subkey), do: Application.get_env(:shopify_api, key)[subkey]
 
@@ -10,4 +9,11 @@ defmodule ShopifyAPI.Config do
 
   def app_name(%Plug.Conn{path_info: path_info}, opts \\ []),
     do: Keyword.get(opts, :app_name) || app_name() || List.last(path_info)
+
+  @spec app() :: ShopifyAPI.App.t() | nil
+  def app do
+    with app_name when is_binary(app_name) <- app_name() do
+      ShopifyAPI.AppServer.get(app_name)
+    end
+  end
 end

--- a/lib/shopify_api/model/webhook_scope.ex
+++ b/lib/shopify_api/model/webhook_scope.ex
@@ -1,0 +1,22 @@
+defmodule ShopifyAPI.Model.WebhookScope do
+  @type t() :: %__MODULE__{
+          shopify_api_version: String.t(),
+          shopify_webhook_id: String.t(),
+          # Using the Shopify CLI the event id can be unset
+          shopify_event_id: String.t() | nil,
+          topic: String.t(),
+          myshopify_domain: String.t(),
+          app: ShopifyAPI.App.t(),
+          shop: ShopifyAPI.Shop.t()
+        }
+
+  defstruct [
+    :shopify_api_version,
+    :shopify_webhook_id,
+    :shopify_event_id,
+    :topic,
+    :myshopify_domain,
+    :app,
+    :shop
+  ]
+end

--- a/lib/shopify_api/plugs/webhook.ex
+++ b/lib/shopify_api/plugs/webhook.ex
@@ -1,4 +1,5 @@
 defmodule ShopifyAPI.Plugs.Webhook do
+  @deprecated "Please use the WebhookHMACValidator and WebhookScopeSetup see the readme for examples"
   @moduledoc """
   A Plug to handle incoming webhooks from Shopify.
 

--- a/lib/shopify_api/plugs/webhook_ensure_validation.ex
+++ b/lib/shopify_api/plugs/webhook_ensure_validation.ex
@@ -1,0 +1,21 @@
+defmodule ShopifyAPI.Plugs.WebhookEnsureValidation do
+  require Logger
+  import Plug.Conn, only: [send_resp: 3, halt: 1]
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{assigns: %{shopify_hmac_validated: true}} = conn, _opts), do: conn
+
+  def call(%Plug.Conn{assigns: %{shopify_hmac_validated: false}} = conn, _opts),
+    do: send_failure(conn, "HMAC was invalid")
+
+  def call(conn, _opts), do: send_failure(conn, "HMAC validation did not happen")
+
+  defp send_failure(conn, msg) do
+    Logger.error(msg)
+
+    conn
+    |> send_resp(200, "Failed HMAC Validation")
+    |> halt()
+  end
+end

--- a/lib/shopify_api/plugs/webhook_scope_setup.ex
+++ b/lib/shopify_api/plugs/webhook_scope_setup.ex
@@ -1,0 +1,68 @@
+defmodule ShopifyAPI.Plugs.WebhookScopeSetup do
+  @moduledoc """
+  The Webhook Scope Setup plug reads all the shopify headers and assigns
+  a %Model.WebHookScope{} to the conn.
+
+  ## Options
+
+  - app_name: optional, the name of the app for look up in the AppServer if left blank
+    it will use the Application Config or the last element of the request path.
+
+  ## Usage
+
+  This should be put in a pipeline afer the ensure validation plug in your router
+  on your webhook endpoint.
+
+  ```elixir
+  pipeline :shopify_webhook do
+    plug ShopifyAPI.Plugs.WebhookEnsureValidation
+    plug ShopifyAPI.Plugs.WebhookScopeSetup
+  end
+  ```
+  """
+  require Logger
+
+  import Plug.Conn, only: [assign: 3, get_req_header: 2]
+
+  @shopify_topic_header "x-shopify-topic"
+  @shopify_myshopify_domain_header "x-shopify-shop-domain"
+  @shopify_api_version_header "x-shopify-api-version"
+  @shopify_webhook_id_header "x-shopify-webhook-id"
+  @shopify_event_id_header "x-shopify-event-id"
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{} = conn, opts) do
+    with app_name when is_binary(app_name) <- ShopifyAPI.Config.app_name(conn, opts),
+         {:ok, %ShopifyAPI.App{} = app} <- ShopifyAPI.AppServer.get(app_name),
+         myshopify_domain when is_binary(myshopify_domain) <- myshopify_domain(conn) do
+      webhook_scope = %ShopifyAPI.Model.WebhookScope{
+        shopify_api_version: shopify_api_version(conn),
+        shopify_webhook_id: shopify_webhook_id(conn),
+        shopify_event_id: shopify_event_id(conn),
+        topic: webhook_topic(conn),
+        myshopify_domain: myshopify_domain,
+        app: app,
+        shop: ShopifyAPI.ShopServer.find(myshopify_domain)
+      }
+
+      assign(conn, :webhook_scope, webhook_scope)
+    else
+      error ->
+        Logger.debug("error setting up webhook scope #{inspect(error)}")
+        conn
+    end
+  end
+
+  @spec webhook_topic(Plug.Conn.t()) :: String.t() | nil
+  def webhook_topic(%Plug.Conn{} = conn), do: get_header(conn, @shopify_topic_header)
+
+  def myshopify_domain(%Plug.Conn{} = conn),
+    do: get_header(conn, @shopify_myshopify_domain_header)
+
+  def shopify_api_version(%Plug.Conn{} = conn), do: get_header(conn, @shopify_api_version_header)
+  def shopify_webhook_id(%Plug.Conn{} = conn), do: get_header(conn, @shopify_webhook_id_header)
+  def shopify_event_id(%Plug.Conn{} = conn), do: get_header(conn, @shopify_event_id_header)
+
+  defp get_header(conn, key), do: conn |> get_req_header(key) |> List.first()
+end

--- a/lib/shopify_api/shop_server.ex
+++ b/lib/shopify_api/shop_server.ex
@@ -34,6 +34,14 @@ defmodule ShopifyAPI.ShopServer do
     end
   end
 
+  @spec get(String.t()) :: Shop.t() | nil
+  def find(domain) do
+    case get(domain) do
+      {:ok, shop} -> shop
+      _ -> nil
+    end
+  end
+
   @spec get_or_create(String.t(), boolean()) :: {:ok, Shop.t()}
   def get_or_create(domain, should_persist \\ true) do
     case get(domain) do

--- a/lib/shopify_api/webhook_hmac_validator.ex
+++ b/lib/shopify_api/webhook_hmac_validator.ex
@@ -1,0 +1,57 @@
+defmodule ShopifyAPI.WebhookHMACValidator do
+  @moduledoc """
+  A custom body reader to handle authenticating incoming webhooks from Shopify.
+
+  This plug reads the body and verifies the HMAC if the header is present setting a
+  `shopify_hmac_validated` on the conn's assigns.
+
+  ## Usage
+
+  Add the following configuration to your endpoint.ex for the Plug.Parser config.
+  `body_reader: {ShopifyAPI.WebhookHMACValidator, :read_body, []},`
+
+  Should now look something like:
+  ```elixir
+  plug Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    body_reader: {ShopifyAPI.WebhookHMACValidator, :read_body, []},
+    json_decoder: Phoenix.json_library()
+  ```
+
+  ## Options
+
+  - app_name: optional, the name of the app for look up in the AppServer if left blank
+    it will use the Application Config or the last element of the request path.
+  """
+  require Logger
+  import Plug.Conn, only: [assign: 3, get_req_header: 2]
+
+  @shopify_hmac_header "x-shopify-hmac-sha256"
+
+  def read_body(conn, opts) do
+    with {:ok, body, conn} <- Plug.Conn.read_body(conn, opts) do
+      conn = assign_hmac_validation(conn, body, opts)
+      {:ok, body, conn}
+    end
+  end
+
+  def assign_hmac_validation(conn, body, opts) do
+    with shopify_hmac when is_binary(shopify_hmac) <- get_header(conn, @shopify_hmac_header),
+         app_name when is_binary(app_name) <- ShopifyAPI.Config.app_name(conn, opts),
+         {:ok, %ShopifyAPI.App{client_secret: client_secret}} <-
+           ShopifyAPI.AppServer.get(app_name) do
+      payload_hmac = ShopifyAPI.Security.base64_sha256_hmac(body, client_secret)
+
+      assign(
+        conn,
+        :shopify_hmac_validated,
+        Plug.Crypto.secure_compare(shopify_hmac, payload_hmac)
+      )
+    else
+      _ -> conn
+    end
+  end
+
+  defp get_header(conn, key), do: conn |> get_req_header(key) |> List.first()
+end

--- a/test/shopify_api/plugs/webhook_scope_setup_test.exs
+++ b/test/shopify_api/plugs/webhook_scope_setup_test.exs
@@ -1,0 +1,69 @@
+defmodule ShopifyAPI.Plugs.WebhookScopeSetupTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+  import Plug.Conn
+  import ShopifyAPI.Factory
+
+  alias ShopifyAPI.{AppServer, ShopServer}
+  alias ShopifyAPI.Model
+  alias ShopifyAPI.Plugs.WebhookScopeSetup
+
+  setup do
+    app = build(:app)
+    shop = build(:shop)
+    AppServer.set(app)
+    ShopServer.set(shop)
+
+    conn =
+      :post
+      |> conn("/shopify/webhooks/", Jason.encode!(%{"id" => 1234}))
+      |> put_req_header("content-type", "application/json")
+
+    [conn: conn, app: app, shop: shop]
+  end
+
+  @api_version "2025-04"
+  @topic "orders/create"
+
+  describe "call/2 with app name and myshopify domain" do
+    test "sets webhook scope on assigns", %{conn: conn, app: app, shop: shop} do
+      conn =
+        conn
+        |> put_req_header("x-shopify-shop-domain", shop.domain)
+        |> put_req_header("x-shopify-topic", @topic)
+        |> put_req_header("x-shopify-api-version", @api_version)
+        |> WebhookScopeSetup.call([])
+
+      %{assigns: %{webhook_scope: %Model.WebhookScope{} = webhook_scope}} = conn
+      assert webhook_scope.myshopify_domain == shop.domain
+      assert webhook_scope.shop == shop
+      assert webhook_scope.app == app
+      assert webhook_scope.topic == @topic
+      assert webhook_scope.shopify_api_version == @api_version
+    end
+  end
+
+  describe "call/2 without required inputs" do
+    test "without an app name the scope is not set", %{conn: conn, shop: shop} do
+      conn =
+        conn
+        |> put_req_header("x-shopify-shop-domain", shop.domain)
+        |> put_req_header("x-shopify-topic", @topic)
+        |> put_req_header("x-shopify-api-version", @api_version)
+        |> WebhookScopeSetup.call(app_name: "invalid")
+
+      refute conn.assigns[:webhook_scope]
+    end
+
+    test "without a shop myshopify_domain scope is not set", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("x-shopify-topic", @topic)
+        |> put_req_header("x-shopify-api-version", @api_version)
+        |> WebhookScopeSetup.call([])
+
+      refute conn.assigns[:webhook_scope]
+    end
+  end
+end

--- a/test/shopify_api/webhook_hmac_validator_text.exs
+++ b/test/shopify_api/webhook_hmac_validator_text.exs
@@ -1,0 +1,72 @@
+defmodule ShopifyAPI.WebhookHMACValidatorTest do
+  use ExUnit.Case, async: true
+
+  import Plug.Test
+  import Plug.Conn
+  import ShopifyAPI.Factory
+
+  alias ShopifyAPI.AppServer
+  alias ShopifyAPI.WebhookHMACValidator
+
+  setup do
+    app = build(:app)
+    AppServer.set(app)
+
+    {hmac, payload} = encode_with_hmac(app, %{"id" => 1234})
+
+    conn =
+      :post
+      |> conn("/shopify/webhooks/testapp", payload)
+      |> put_req_header("content-type", "application/json")
+
+    [conn: conn, app: app, payload: payload, hmac: hmac]
+  end
+
+  describe "read_body/2 with required attributes set" do
+    test "happy path", %{conn: conn, payload: payload, hmac: hmac} do
+      {:ok, body, conn} =
+        conn
+        |> put_req_header("x-shopify-hmac-sha256", hmac)
+        |> WebhookHMACValidator.read_body([])
+
+      assert body == payload
+      assert conn.assigns.shopify_hmac_validated
+    end
+
+    test "with invalid hmac", %{conn: conn, payload: payload} do
+      {:ok, body, conn} =
+        conn
+        |> put_req_header("x-shopify-hmac-sha256", "invalid")
+        |> WebhookHMACValidator.read_body([])
+
+      assert body == payload
+      refute conn.assigns.shopify_hmac_validated
+    end
+  end
+
+  describe "read_body/2 with some missing attributes" do
+    test "without the hmac header", %{conn: conn, payload: payload} do
+      {:ok, body, conn} = WebhookHMACValidator.read_body(conn, [])
+      assert body == payload
+      refute conn.assigns[:shopify_hmac_validated]
+    end
+
+    test "with an invalid app_name", %{conn: conn, payload: payload, hmac: hmac} do
+      {:ok, body, conn} =
+        conn
+        |> put_req_header("x-shopify-hmac-sha256", hmac)
+        |> WebhookHMACValidator.read_body(app_name: "invalid")
+
+      assert body == payload
+      refute conn.assigns[:shopify_hmac_validated]
+    end
+  end
+
+  # Encodes an object as JSON, generating a HMAC string for integrity verification.
+  # Returns a two-tuple containing the Base64-encoded HMAC and JSON payload string.
+  defp encode_with_hmac(%{client_secret: secret}, payload) do
+    json = Jason.encode!(payload)
+    hmac = Base.encode64(:crypto.mac(:hmac, :sha256, secret, json))
+    {hmac, json}
+  end
+end


### PR DESCRIPTION
- moved to using a body reader for validation
- ensure validation moved in to its own plug
- all the logic for settings assigns (shop, topic, etc) moved in to its own plug
- setup of the route for the webhooks should now happen in the router.ex
- handling and business logic for webhooks should now happen in a controller