### PR TITLE
cut ver 0.16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.16.6
+
 - New: Add support for passing options to `ShopifyAPI.Bulk.Query.exec/3`, with `group_objects`
   as a new option to group the returned objects by a specified key.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The package can be installed by adding `shopify_api` to your list of dependencie
 ```elixir
 def deps do
   [
-    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.16.5"}
+    {:shopify_api, github: "pixelunion/elixir-shopifyapi", tag: "v0.16.6"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Plug.ShopifyAPI.MixProject do
   use Mix.Project
 
-  @version "0.16.5"
+  @version "0.16.6"
 
   def project do
     [


### PR DESCRIPTION
Adds ability to pass options to Bulk queries and adds the group_object option for [Shopify's new change](https://shopify.dev/changelog/bulk-operations-group-objects-default-changed-to-false)